### PR TITLE
feat/#168: 회원가입 시 이메일 중복 검사 API 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -129,4 +129,18 @@ public class UserController {
         return ApiResponse.onSuccess(users);
     }
 
+    @Operation(summary = "이메일 중복 검사 [v1.0 (2025-08-05)]", description =
+            "# [v1.0 (2025-08-05)](https://www.notion.so/API-21e5da7802c581cca23dff937ac3f155?p=22a5da7802c580c0b553c6223d3efe53&pm=s)" +
+                    " 회원가입 시 이미 가입된 회원의 이메일인지 중복 검사하는 API입니다."
+    )
+    @PostMapping("/signup/same")
+    public ApiResponse<UserResponseDTO.CheckEmailDuplicationResponse> checkEmailDuplication(
+            @RequestBody UserRequestDTO.CheckEmailDuplicationRequest request
+    ) {
+        return ApiResponse.onSuccess(
+                userCommandService.checkEmailDuplication(
+                        request
+                )
+        );
+    }
 }

--- a/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
@@ -42,4 +42,13 @@ public class UserRequestDTO {
         private String name;
         private String password;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CheckEmailDuplicationRequest {
+        @NotBlank(message = "이메일은 빈값일 수 없습니다.")
+        private String email;
+    }
 }

--- a/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
@@ -2,6 +2,7 @@ package com.haru.api.domain.user.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.haru.api.domain.user.entity.enums.EmailStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -39,5 +40,11 @@ public class UserResponseDTO {
     public static class MemberInfo {
         private String email;
         private String name;
+    }
+
+    @Getter
+    @Builder
+    public static class CheckEmailDuplicationResponse {
+        private EmailStatus emailStatus;
     }
 }

--- a/src/main/java/com/haru/api/domain/user/entity/enums/EmailStatus.java
+++ b/src/main/java/com/haru/api/domain/user/entity/enums/EmailStatus.java
@@ -1,0 +1,5 @@
+package com.haru.api.domain.user.entity.enums;
+
+public enum EmailStatus {
+    AVAILABLE, UNAVAILABLE
+}

--- a/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
@@ -38,7 +38,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/ws/audio/**",
             "/api/v1/workspaces/invite-accept",
             "/api/v1/terms",
-            "/api/v1/sns/oauth/callback"
+            "/api/v1/sns/oauth/callback",
+            "/api/v1/users/signup/same"
     };
     private final JwtUtils jwtUtils;
     private final RedisTemplate<String, String> redisTemplate;

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
@@ -17,4 +17,6 @@ public interface UserCommandService {
     String generateAccessToken(Long userId, int accessExpTime);
 
     String generateAndSaveRefreshToken(String key, int refreshExpTime);
+
+    UserResponseDTO.CheckEmailDuplicationResponse checkEmailDuplication(UserRequestDTO.CheckEmailDuplicationRequest request);
 }

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.haru.api.domain.user.converter.UserConverter;
 import com.haru.api.domain.user.dto.UserRequestDTO;
 import com.haru.api.domain.user.dto.UserResponseDTO;
 import com.haru.api.domain.user.entity.User;
+import com.haru.api.domain.user.entity.enums.EmailStatus;
 import com.haru.api.domain.user.repository.UserRepository;
 import com.haru.api.domain.user.security.jwt.JwtUtils;
 import com.haru.api.domain.user.security.jwt.SecurityUtil;
@@ -142,5 +143,20 @@ public class UserCommandServiceImpl implements UserCommandService{
         String refreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
         redisTemplate.opsForValue().set(key, refreshToken, refreshExpTime, TimeUnit.SECONDS);
         return refreshToken;
+    }
+
+    @Override
+    public UserResponseDTO.CheckEmailDuplicationResponse checkEmailDuplication(UserRequestDTO.CheckEmailDuplicationRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElse(null);
+        if (user == null) {
+            return UserResponseDTO.CheckEmailDuplicationResponse.builder()
+                    .emailStatus(EmailStatus.AVAILABLE)
+                    .build();
+        } else {
+            return UserResponseDTO.CheckEmailDuplicationResponse.builder()
+                    .emailStatus(EmailStatus.UNAVAILABLE)
+                    .build();
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #168

## 📝작업 내용
> 회원가입 시 이메일 중복 검사 API 구현 완료

## 🔎코드 설명(스크린샷(선택))
> email을 url에 노출시키지 않기 위해 Http Method를 Post로 설정하고 Request Body에 email을 담음.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x