### PR TITLE
feat/#173: 프론트엔드 테스트위한 모든 도메인 요청 CORS 허용

### DIFF
--- a/src/main/java/com/haru/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/haru/api/global/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000", "https://haru.it.kr", "https://api.haru.it.kr"));
+        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000", "https://haru.it.kr", "https://api.haru.it.kr", "*"));
         configuration.setAllowedMethods(Arrays.asList("*"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/haru/api/global/config/WebConfig.java
+++ b/src/main/java/com/haru/api/global/config/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("http://localhost:3000", "https://haru.it.kr", "https://api.haru.it.kr") // 프론트엔드 주소 추가
+                .allowedOriginPatterns("http://localhost:3000", "https://haru.it.kr", "https://api.haru.it.kr", "*") // 프론트엔드 주소 추가
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
## #️⃣연관된 이슈
> #173

## 📝작업 내용
> 프론트엔드 테스트위한 모든 도메인 요청 CORS 허용

## 🔎코드 설명(스크린샷(선택))
> WebConfig와 SecurityConfig에 모든 도메인 요청 CORS 허용하도록 수정

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x