### PR TITLE
feat/#170: SNS 이벤트 참여자 또는 당첨자 리스트를 PDF파일 또는 DOCX파일로 다운로드하는 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,15 @@ dependencies {
 	implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
 	implementation 'org.docx4j:docx4j-export-fo:8.3.3'
 
+	// Openhtmltopdf core
+	implementation 'com.openhtmltopdf:openhtmltopdf-core:1.0.10'
+	implementation 'com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10'
 
+	// OpenPDF, iText 2.x기반
+	implementation 'com.github.librepdf:openpdf:1.3.39'
+
+	// Apache POI의 XWPF(XML Word Processing Format)
+	implementation 'org.apache.poi:poi-ooxml:5.2.5'
 }
 
 dependencyManagement {

--- a/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventRequestDTO.java
@@ -36,4 +36,12 @@ public class SnsEventRequestDTO {
     public static class UpdateSnsEventRequest {
         private String title;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DownloadListRequest {
+        private String listHtml;
+    }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/entity/enums/Format.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/entity/enums/Format.java
@@ -1,0 +1,5 @@
+package com.haru.api.domain.snsEvent.entity.enums;
+
+public enum Format {
+    PDF, DOCX
+}

--- a/src/main/java/com/haru/api/domain/snsEvent/entity/enums/ListType.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/entity/enums/ListType.java
@@ -1,0 +1,5 @@
+package com.haru.api.domain.snsEvent.entity.enums;
+
+public enum ListType {
+    PARTICIPANT, WINNER
+}

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
@@ -2,6 +2,8 @@ package com.haru.api.domain.snsEvent.service;
 
 import com.haru.api.domain.snsEvent.dto.SnsEventRequestDTO;
 import com.haru.api.domain.snsEvent.dto.SnsEventResponseDTO;
+import com.haru.api.domain.snsEvent.entity.enums.Format;
+import com.haru.api.domain.snsEvent.entity.enums.ListType;
 
 public interface SnsEventCommandService {
     SnsEventResponseDTO.CreateSnsEventResponse createSnsEvent(Long workspaceId, SnsEventRequestDTO.CreateSnsRequest request);
@@ -11,4 +13,6 @@ public interface SnsEventCommandService {
     void updateSnsEventTitle(Long userId, Long snsEventId, SnsEventRequestDTO.UpdateSnsEventRequest request);
 
     void deleteSnsEvent(Long userId, Long snsEventId);
+
+    byte[] downloadList(Long userId, Long snsEventId, ListType listType, Format format, SnsEventRequestDTO.DownloadListRequest request);
 }

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -70,7 +70,9 @@ public enum ErrorStatus implements BaseErrorCode {
     SNS_EVENT_NO_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "SNS_EVENT4006", "인스타그램 액세스 토큰이 없습니다."),
     SNS_EVENT_NO_AUTHORITY(HttpStatus.UNAUTHORIZED, "SNS_EVENT4007", "인스타그램 이벤트에 대한 수정 권한이 없습니다."),
     SNS_EVENT_INSTAGRAM_ALREADY_LINKED(HttpStatus.BAD_REQUEST, "SNS_EVENT4008", "이미 연동된 인스타그램 계정입니다."),
-  
+    SNS_EVENT_WRONG_FORMAT(HttpStatus.BAD_REQUEST, "SNS_EVENT4009", "잘못된 다운로드 파일 형식입니다."),
+    SNS_EVENT_DOWNLOAD_LIST_ERROR(HttpStatus.BAD_REQUEST, "SNS_EVENT4010", "리스트 다운로드중 오류가 발생했습니다."),
+
     // last opened 관련 에러
     USER_DOCUMENT_LAST_OPENED_NOT_FOUND(HttpStatus.NOT_FOUND, "LASTOPENED4001", "해당 문서에 대한 마지막 조회 데이터가 존재하지 않습니다."),
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #170 

## 📝작업 내용
> SNS 이벤트 참여자 또는 당첨자 리스트를 PDF파일 또는 DOCX파일로 다운로드하는 API 구현

## 🔎코드 설명(스크린샷(선택))
> PDF파일은 프론트엔드에서 리스트가 포함된 HTML을 받아 생성
> HTML을 PDF파일로 변환할때는 Openhtmltopdf라이브러리 사용
> 생성된 PDF파일을 조작할때는 OpenPDF라이브러리 사용
> DOCX파일은 DB에 저장돼 있는 리스트를 활용해 DOCX파일내에 표를 생성
> DOCX파일을 생성할때는 Apache POI라이브러리 중 XWPF컴포넌트 사용

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x