### PR TITLE
feat/#186: 문서 업로드 및 썸네일 생성 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,14 @@ dependencies {
 	implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
 	implementation 'org.docx4j:docx4j-export-fo:8.3.3'
 
+	// pdf
+	// 1. Markdown -> HTML 변환
+	implementation 'org.commonmark:commonmark:0.21.0'
+	// 2. HTML -> PDF 변환 (핵심 엔진)
+	implementation 'com.openhtmltopdf:openhtmltopdf-core:1.0.10'
+	// 3. PDF 생성을 위한 렌더러 (PDFBox 사용)
+	implementation 'com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10'
+
 
 }
 

--- a/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
+++ b/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
@@ -1,0 +1,86 @@
+package com.haru.api.infra.s3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarkdownFileUploader {
+
+    private final MarkdownToPdfConverter markdownToPdfConverter;
+    private final ThumbnailGeneratorService thumbnailGeneratorService;
+    private final AmazonS3Manager amazonS3Manager;
+
+    private static final String IMAGE_FORMAT = "png";
+
+    /**
+     * PDF만 생성 및 업로드
+     * Markdown 텍스트를 PDF로 변환하여 S3에 업로드하고, 생성된 PDF의 key를 반환
+     *
+     * @param markdownText PDF로 변환할 Markdown 내용
+     * @param featurePath 파일이 저장될 기능별 경로 (예: "aimeeting")
+     * @return 생성된 PDF 파일의 S3 key
+     */
+    public String createOrUpdatePdf(String markdownText, String featurePath, String existingPdfKey) {
+        // 1. Markdown을 PDF 데이터로 변환
+        byte[] pdfBytes = markdownToPdfConverter.convert(markdownText);
+
+        // 2. 사용할 PDF 키 결정
+        String pdfKeyToUse;
+        if (existingPdfKey != null && !existingPdfKey.isBlank()) {
+            // 기존 키가 제공되면, 그 키를 그대로 사용하여 갱신(덮어쓰기)
+            pdfKeyToUse = existingPdfKey;
+            log.info("기존 PDF 갱신을 시작합니다. Key: {}", pdfKeyToUse);
+        } else {
+            // 기존 키가 없으면, 새로운 키를 생성
+            pdfKeyToUse = amazonS3Manager.generateKeyName("pdfs/" + featurePath, UUID.randomUUID()) + ".pdf";
+            log.info("새로운 PDF 생성을 시작합니다. New Key: {}", pdfKeyToUse);
+        }
+
+        // 3. 결정된 키로 PDF 파일을 S3에 업로드
+        amazonS3Manager.uploadFile(pdfKeyToUse, pdfBytes, "application/pdf");
+        log.info("PDF 업로드/갱신 성공. Key: {}", pdfKeyToUse);
+
+        // 4. 사용된 PDF의 key를 반환
+        return pdfKeyToUse;
+    }
+
+    /**
+     * 썸네일만 생성 및 업로드
+     * 기존 PDF 파일의 key를 받아 썸네일을 생성하고 S3에 업로드
+     *
+     * @param pdfKey 썸네일을 생성할 원본 PDF의 키
+     * @param featurePath 썸네일이 저장될 기능별 경로
+     * @return 생성된 썸네일의 새로운 key
+     */
+    public String createOrUpdateThumbnail(String pdfKey, String featurePath, String existingThumbnailKey) {
+        // 1. S3에서 원본 PDF 파일 다운로드
+        byte[] pdfBytes = amazonS3Manager.downloadFile(pdfKey);
+
+        // 2. 다운로드한 PDF로 새로운 썸네일 데이터 생성
+        byte[] newThumbnailBytes = thumbnailGeneratorService.generate(pdfBytes);
+
+        // 3. 사용할 썸네일 키 결정
+        String thumbnailKeyToUse;
+        if (existingThumbnailKey != null && !existingThumbnailKey.isBlank()) {
+            // 기존 키가 제공되면, 그 키를 그대로 사용하여 갱신(덮어쓰기)
+            thumbnailKeyToUse = existingThumbnailKey;
+            log.info("기존 썸네일 갱신을 시작합니다. Key: {}", thumbnailKeyToUse);
+        } else {
+            // 기존 키가 없으면, 새로운 키를 생성
+            thumbnailKeyToUse = amazonS3Manager.generateKeyName("thumbnails/" + featurePath, UUID.randomUUID()) + "." + IMAGE_FORMAT;
+            log.info("새로운 썸네일 생성을 시작합니다. New Key: {}", thumbnailKeyToUse);
+        }
+
+        // 4. 결정된 키로 썸네일을 S3에 업로드
+        amazonS3Manager.uploadFile(thumbnailKeyToUse, newThumbnailBytes, "image/" + IMAGE_FORMAT);
+        log.info("썸네일 업로드/갱신 성공. Key: {}", thumbnailKeyToUse);
+
+        // 5. 사용된 썸네일의 key를 반환
+        return thumbnailKeyToUse;
+    }
+}

--- a/src/main/java/com/haru/api/infra/s3/MarkdownToPdfConverter.java
+++ b/src/main/java/com/haru/api/infra/s3/MarkdownToPdfConverter.java
@@ -1,0 +1,44 @@
+package com.haru.api.infra.s3;
+
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+
+@Slf4j
+@Component
+public class MarkdownToPdfConverter {
+
+    // Markdown 문자열 -> HTML , HTML -> PDF byte[] 변환
+    public byte[] convert(String markdownText) {
+        try {
+            // 1. Markdown -> HTML
+            Parser parser = Parser.builder().build();
+            Node document = parser.parse(markdownText);
+            HtmlRenderer renderer = HtmlRenderer.builder().build();
+            String htmlContent = renderer.render(document);
+
+            // 2. HTML -> PDF
+            try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                PdfRendererBuilder builder = new PdfRendererBuilder();
+                builder.useFastMode();
+                // 폰트
+                builder.useFont(new File(getClass().getClassLoader().getResource("/templates/NotoSansKR-Regular.ttf").getFile()), "NanumGothic");
+                builder.withHtmlContent(htmlContent, null);
+                builder.toStream(os);
+                builder.run();
+                log.info("Markdown to PDF 변환 성공");
+                return os.toByteArray();
+            }
+        } catch (Exception e) {
+            log.error("Markdown to PDF 변환 중 오류 발생", e);
+            throw new RuntimeException("PDF 데이터 생성에 실패했습니다.", e);
+        }
+    }
+}
+

--- a/src/main/java/com/haru/api/infra/s3/ThumbnailGeneratorService.java
+++ b/src/main/java/com/haru/api/infra/s3/ThumbnailGeneratorService.java
@@ -1,0 +1,41 @@
+package com.haru.api.infra.s3;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.springframework.stereotype.Component;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ThumbnailGeneratorService {
+
+    private static final int DPI = 150;
+    private static final String IMAGE_FORMAT = "png";
+
+    // pdf byte[] -> 썸네일 이미지 생성
+    public byte[] generate(byte[] pdfBytes) {
+        if (pdfBytes == null || pdfBytes.length == 0) {
+            throw new IllegalArgumentException("PDF 데이터가 비어있습니다.");
+        }
+        try (PDDocument document = PDDocument.load(pdfBytes)) {
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            BufferedImage bufferedImage = pdfRenderer.renderImageWithDPI(0, DPI);
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                ImageIO.write(bufferedImage, IMAGE_FORMAT, baos);
+                log.info("PDF 썸네일 생성 성공");
+                return baos.toByteArray();
+            }
+        } catch (Exception e) {
+            log.error("PDF 썸네일 생성 중 오류 발생", e);
+            throw new RuntimeException("썸네일 생성에 실패했습니다.", e);
+        }
+    }
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #186 

## 📝작업 내용
> multipart로 받은 파일 뿐만 아니라 domain의 markdown String을 pdf파일로 생성하여 S3에 업로드하는 메서드 추가
파일 생성과 썸네일 생성 순간의 차이 때문에 서로 다른 메서드로 분리하여 작성


## 🔎코드 설명(스크린샷(선택))
```java
//markdown String을 통하여 pdf파일을 생성해 S3에 업로드 및 갱신
String pdfKey = markdownFileUploader.createOrUpdatePdf(String markdownContent, 파일정리를 위한 기능명 "aimeeting", 기존의 keyName (없으면 null) domain.getPdfFileKey());

//파일의 key를 통하여 썸네일을 생성해 S3에 업로드 및 갱신
String thumbnailKey = markdownFileUploader.createOrUpdateThumbnail(String pdfKey (썸네일을 만들 파일의 S3 key), 파일정리를 위한 기능명 "aimeeting",기존의 keyName (없으면 null) domain.getThumbnailKey());

//key를 통해 presignedUrl을 생성하여 프론트로 반환
String pdfUrl = amazonS3Manager.generatePresignedUrl(meeting.getPdfFileKey());
```
- domain Service에서 활용할 메서드
- createOrUpdatePdf는 분석결과 markdown을 받아 S3에 업로드후 key반환
- createOrUpdateThumbnail은 업로드되어있는 pdf파일로부터 썸네일을 생성하여 key반환
- 공통적으로 existingKey를 받아 null이면 key를 생성해주고, 기존의 key가 있다면 파일을 갱신 및 기존 key사용

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
