### PR TITLE
feat/#190: 어노테이션, 인터셉터를 통한 유저, 워크스페이스 검증 자동화

### DIFF
--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -1,7 +1,6 @@
 package com.haru.api.domain.meeting.repository;
 
 import com.haru.api.domain.meeting.entity.Meeting;
-import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 import com.haru.api.domain.workspace.entity.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,19 +21,9 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     List<Meeting> findAllByWorkspaceId(Long workspaceId);
 
-//    @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$DocumentCalendar(" +
-//            "mt.id, " +
-//            "mt.title, " +
-//            "com.haru.api.domain.lastOpened.entity.enums.DocumentType.AI_MEETING_MANAGER, " +
-//            "mt.createdAt) " +
-//            "FROM Meeting mt " +
-//            "WHERE mt.workspace.id = :workspaceId " +
-//            "AND mt.createdAt BETWEEN :startDate AND :endDate")
-//    List<WorkspaceResponseDTO.DocumentCalendar> findAllDocumentForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
-
     @Query("SELECT mt FROM Meeting mt " +
-            "WHERE mt.workspace.id = :workspaceId " +
+            "WHERE mt.workspace = :workspace " +
             "AND mt.createdAt BETWEEN :startDate AND :endDate")
-    List<Meeting> findAllDocumentForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
+    List<Meeting> findAllDocumentForCalendars(Workspace workspace, LocalDateTime startDate, LocalDateTime endDate);
 
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
@@ -1,7 +1,7 @@
 package com.haru.api.domain.moodTracker.repository;
 
 import com.haru.api.domain.moodTracker.entity.MoodTracker;
-import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
+import com.haru.api.domain.workspace.entity.Workspace;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -20,18 +20,9 @@ public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> 
     @Query("UPDATE MoodTracker m SET m.respondentsNum = m.respondentsNum + 1 WHERE m.id = :moodTrackerId")
     void addRespondentsNum(Long moodTrackerId);
 
-//    @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$DocumentCalendar(" +
-//            "se.id, " +
-//            "se.title, " +
-//            "com.haru.api.domain.lastOpened.entity.enums.DocumentType.SNS_EVENT_ASSISTANT, " +
-//            "se.createdAt) " +
-//            "FROM SnsEvent se " +
-//            "WHERE se.workspace.id = :workspaceId " +
-//            "AND se.createdAt BETWEEN :startDate AND :endDate")
-//    List<WorkspaceResponseDTO.DocumentCalendar> findAllDocumentForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
 
     @Query("SELECT mt FROM MoodTracker mt " +
-            "WHERE mt.workspace.id = :workspaceId " +
+            "WHERE mt.workspace = :workspace " +
             "AND mt.createdAt BETWEEN :startDate AND :endDate")
-    List<MoodTracker> findAllDocumentForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
+    List<MoodTracker> findAllDocumentForCalendars(Workspace workspace, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
@@ -1,16 +1,13 @@
 package com.haru.api.domain.snsEvent.repository;
 
 import com.haru.api.domain.snsEvent.entity.SnsEvent;
-import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 import com.haru.api.domain.workspace.entity.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
@@ -19,18 +16,9 @@ public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
 
     List<SnsEvent> findAllByWorkspace(Workspace foundWorkspace);
 
-//    @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$DocumentCalendar(" +
-//            "se.id, " +
-//            "se.title, " +
-//            "com.haru.api.domain.lastOpened.entity.enums.DocumentType.SNS_EVENT_ASSISTANT, " +
-//            "se.createdAt) " +
-//            "FROM SnsEvent se " +
-//            "WHERE se.workspace.id = :workspaceId " +
-//            "AND se.createdAt BETWEEN :startDate AND :endDate")
-//    List<WorkspaceResponseDTO.DocumentCalendar> findAllDocumentForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
 
     @Query("SELECT mt FROM SnsEvent mt " +
-            "WHERE mt.workspace.id = :workspaceId " +
+            "WHERE mt.workspace = :workspace " +
             "AND mt.createdAt BETWEEN :startDate AND :endDate")
-    List<SnsEvent> findAllDocumentForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
+    List<SnsEvent> findAllDocumentForCalendars(Workspace workspace, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
@@ -36,6 +36,6 @@ public interface UserWorkspaceRepository extends JpaRepository<UserWorkspace, Lo
 
     Optional<UserWorkspace> findByWorkspaceAndAuth(Workspace workspace, Auth auth);
 
-    @Query("SELECT uw.user FROM UserWorkspace uw WHERE uw.workspace.id = :workspaceId")
-    List<User> findUsersByWorkspaceId(Long workspaceId);
+    @Query("SELECT uw.user FROM UserWorkspace uw WHERE uw.workspace = :workspace")
+    List<User> findUsersByWorkspace(Workspace workspace);
 }

--- a/src/main/java/com/haru/api/domain/userWorkspace/service/UserWorkspaceQueryService.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/service/UserWorkspaceQueryService.java
@@ -1,10 +1,11 @@
 package com.haru.api.domain.userWorkspace.service;
 
+import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.userWorkspace.dto.UserWorkspaceResponseDTO;
 
 import java.util.List;
 
 public interface UserWorkspaceQueryService {
 
-    List<UserWorkspaceResponseDTO.UserWorkspaceWithTitle> getUserWorkspaceList(Long userId);
+    List<UserWorkspaceResponseDTO.UserWorkspaceWithTitle> getUserWorkspaceList(User user);
 }

--- a/src/main/java/com/haru/api/domain/userWorkspace/service/UserWorkspaceQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/service/UserWorkspaceQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.haru.api.domain.userWorkspace.service;
 
+import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.userWorkspace.dto.UserWorkspaceResponseDTO;
 import com.haru.api.domain.userWorkspace.repository.UserWorkspaceRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +15,8 @@ public class UserWorkspaceQueryServiceImpl implements UserWorkspaceQueryService 
     private final UserWorkspaceRepository userWorkspaceRepository;
 
     @Override
-    public List<UserWorkspaceResponseDTO.UserWorkspaceWithTitle> getUserWorkspaceList(Long userId) {
+    public List<UserWorkspaceResponseDTO.UserWorkspaceWithTitle> getUserWorkspaceList(User user) {
 
-        return userWorkspaceRepository.getUserWorkspacesWithTitle(userId);
+        return userWorkspaceRepository.getUserWorkspacesWithTitle(user.getId());
     }
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
@@ -3,17 +3,18 @@ package com.haru.api.domain.workspace.service;
 import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.workspace.dto.WorkspaceRequestDTO;
 import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
+import com.haru.api.domain.workspace.entity.Workspace;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface WorkspaceCommandService {
 
-    WorkspaceResponseDTO.Workspace createWorkspace(Long userId, WorkspaceRequestDTO.WorkspaceCreateRequest request, MultipartFile image);
+    WorkspaceResponseDTO.Workspace createWorkspace(User user, WorkspaceRequestDTO.WorkspaceCreateRequest request, MultipartFile image);
 
-    WorkspaceResponseDTO.Workspace updateWorkspace(Long userId, Long workspaceId, WorkspaceRequestDTO.WorkspaceUpdateRequest request, MultipartFile image);
+    WorkspaceResponseDTO.Workspace updateWorkspace(User user, Workspace workspace, WorkspaceRequestDTO.WorkspaceUpdateRequest request, MultipartFile image);
 
     WorkspaceResponseDTO.InvitationAcceptResult acceptInvite(String token);
 
     WorkspaceResponseDTO.InvitationAcceptResult acceptInvite(String token, User user);
 
-    void sendInviteEmail(Long userId, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request);
+    void sendInviteEmail(User user, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request);
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
@@ -22,7 +22,6 @@ import com.haru.api.domain.workspace.repository.WorkspaceRepository;
 import com.haru.api.domain.workspaceInvitation.entity.WorkspaceInvitation;
 import com.haru.api.domain.workspaceInvitation.repository.WorkspaceInvitationRepository;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
-import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import com.haru.api.global.apiPayload.exception.handler.UserWorkspaceHandler;
 import com.haru.api.global.apiPayload.exception.handler.WorkspaceHandler;
 import com.haru.api.global.apiPayload.exception.handler.WorkspaceInvitationHandler;
@@ -61,10 +60,7 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
 
     @Transactional
     @Override
-    public WorkspaceResponseDTO.Workspace createWorkspace(Long userId, WorkspaceRequestDTO.WorkspaceCreateRequest request, MultipartFile image) {
-
-        User foundUser = userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    public WorkspaceResponseDTO.Workspace createWorkspace(User user, WorkspaceRequestDTO.WorkspaceCreateRequest request, MultipartFile image) {
 
         String imageUrl = null;
 
@@ -82,7 +78,7 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
 
         // users_workspaces 테이블에 생성자 정보 저장
         userWorkspaceRepository.save(UserWorkspace.builder()
-                .user(foundUser)
+                .user(user)
                 .workspace(workspace)
                 .auth(Auth.ADMIN)
                 .build());
@@ -92,31 +88,25 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
 
     @Transactional
     @Override
-    public WorkspaceResponseDTO.Workspace updateWorkspace(Long userId, Long workspaceId, WorkspaceRequestDTO.WorkspaceUpdateRequest request, MultipartFile image) {
+    public WorkspaceResponseDTO.Workspace updateWorkspace(User user, Workspace workspace, WorkspaceRequestDTO.WorkspaceUpdateRequest request, MultipartFile image) {
 
-        User foundUser = userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
-        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
-                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
-
-        UserWorkspace userWorkspace = userWorkspaceRepository.findByWorkspaceIdAndUserId(foundWorkspace.getId(), foundUser.getId())
+        UserWorkspace userWorkspace = userWorkspaceRepository.findByWorkspaceIdAndUserId(workspace.getId(), user.getId())
                 .orElseThrow(() -> new UserWorkspaceHandler(ErrorStatus.USER_WORKSPACE_NOT_FOUND));
 
         if(userWorkspace.getAuth() != Auth.ADMIN)
             throw new WorkspaceHandler(ErrorStatus.WORKSPACE_MODIFY_NOT_ALLOWED);
 
         // 제목 수정
-        foundWorkspace.updateTitle(request.getTitle());
+        workspace.updateTitle(request.getTitle());
 
         // 이미지 수정
         if (image != null) {
             String path = amazonS3Manager.generateKeyName("/workspace/image", UUID.randomUUID());
             String imageUrl = amazonS3Manager.uploadFile(path, image);
-            foundWorkspace.updateImageUrl(imageUrl);
+            workspace.updateImageUrl(imageUrl);
         }
 
-        return WorkspaceConverter.toWorkspaceDTO(foundWorkspace);
+        return WorkspaceConverter.toWorkspaceDTO(workspace);
     }
 
     @Transactional
@@ -203,17 +193,14 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
 
     @Transactional
     @Override
-    public void sendInviteEmail(Long userId, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request) {
+    public void sendInviteEmail(User user, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request) {
         Long workspaceId = request.getWorkspaceId();
         List<String> emails = request.getEmails();
-
-        User foundUser = userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
                 .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
 
-        userWorkspaceRepository.findByUserAndWorkspace(foundUser, foundWorkspace)
+        userWorkspaceRepository.findByUserAndWorkspace(user, foundWorkspace)
                 .orElseThrow(() -> new UserWorkspaceHandler(ErrorStatus.USER_WORKSPACE_NOT_FOUND));
 
         // 이메일마다 invitation 생성하여 저장, 초대 수락 토큰 생성, 초대 이메일 발송
@@ -230,8 +217,8 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
 
             String invitationLink = inviteBaseUrl + "?token=" + token;
 
-            String subject = String.format("[%s] 에서 [%s] 님이 당신을 초대했어요!", foundWorkspace.getTitle(), foundUser.getName());
-            String content = generateInvitationEmailContentHtml(email, foundUser.getName(), foundWorkspace.getTitle(), invitationLink);
+            String subject = String.format("[%s] 에서 [%s] 님이 당신을 초대했어요!", foundWorkspace.getTitle(), user.getName());
+            String content = generateInvitationEmailContentHtml(email, user.getName(), foundWorkspace.getTitle(), invitationLink);
 
             emailSender.send(email, subject, content);
         }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryService.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryService.java
@@ -1,16 +1,18 @@
 package com.haru.api.domain.workspace.service;
 
+import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
+import com.haru.api.domain.workspace.entity.Workspace;
 
 import java.time.LocalDate;
 
 public interface WorkspaceQueryService {
 
-    WorkspaceResponseDTO.DocumentList getDocuments(Long userId, Long workspaceId, String title);
+    WorkspaceResponseDTO.DocumentList getDocuments(User user, Workspace workspace, String title);
 
-    WorkspaceResponseDTO.DocumentSidebarList getDocumentWithoutLastOpenedList(Long userId, Long workspaceId);
+    WorkspaceResponseDTO.DocumentSidebarList getDocumentWithoutLastOpenedList(User user, Workspace workspace);
 
-    WorkspaceResponseDTO.DocumentCalendarList getDocumentForCalendar(Long userId, Long workspaceId, LocalDate startDate, LocalDate endDate);
+    WorkspaceResponseDTO.DocumentCalendarList getDocumentForCalendar(User user, Workspace workspace, LocalDate startDate, LocalDate endDate);
 
-    WorkspaceResponseDTO.WorkspaceEditPage getEditPage(Long userId, Long workspaceId);
+    WorkspaceResponseDTO.WorkspaceEditPage getEditPage(User user, Workspace workspace);
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryServiceImpl.java
@@ -11,14 +11,10 @@ import com.haru.api.domain.snsEvent.repository.SnsEventRepository;
 import com.haru.api.domain.user.converter.UserConverter;
 import com.haru.api.domain.user.dto.UserResponseDTO;
 import com.haru.api.domain.user.entity.User;
-import com.haru.api.domain.user.repository.UserRepository;
 import com.haru.api.domain.userWorkspace.repository.UserWorkspaceRepository;
 import com.haru.api.domain.workspace.converter.WorkspaceConverter;
 import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 import com.haru.api.domain.workspace.entity.Workspace;
-import com.haru.api.domain.workspace.repository.WorkspaceRepository;
-import com.haru.api.global.apiPayload.code.status.ErrorStatus;
-import com.haru.api.global.apiPayload.exception.handler.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,28 +32,14 @@ public class WorkspaceQueryServiceImpl implements WorkspaceQueryService {
     private final MeetingRepository meetingRepository;
     private final SnsEventRepository snsEventRepository;
     private final MoodTrackerRepository moodTrackerRepository;
-    private final UserRepository userRepository;
-    private final WorkspaceRepository workspaceRepository;
     private final UserWorkspaceRepository userWorkspaceRepository;
     private final UserDocumentLastOpenedRepository userDocumentLastOpenedRepository;
     private final WorkspaceConverter workspaceConverter;
 
     @Override
-    public WorkspaceResponseDTO.DocumentList getDocuments(Long userId, Long workspaceId, String title) {
+    public WorkspaceResponseDTO.DocumentList getDocuments(User user, Workspace workspace, String title) {
 
-        // 유저 존재 확인
-        userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
-        // workspace 존재 확인
-        workspaceRepository.findById(workspaceId)
-                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
-
-        // 유저가 워크스페이스에 속해있는지 확인
-        if (!userWorkspaceRepository.existsByUserIdAndWorkspaceId(userId, workspaceId))
-            throw new WorkspaceHandler(ErrorStatus.NOT_BELONG_TO_WORKSPACE);
-
-        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedRepository.findRecentDocumentsByTitle(workspaceId, userId, title);
+        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedRepository.findRecentDocumentsByTitle(workspace.getId(), user.getId(), title);
 
         return WorkspaceConverter.toDocumentList(
                 documentList.stream()
@@ -67,22 +49,10 @@ public class WorkspaceQueryServiceImpl implements WorkspaceQueryService {
     }
 
     @Override
-    public WorkspaceResponseDTO.DocumentSidebarList getDocumentWithoutLastOpenedList(Long userId, Long workspaceId) {
-
-        // 유저 존재 확인
-        userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
-        // workspace 존재 확인
-        workspaceRepository.findById(workspaceId)
-                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
-
-        // 유저가 워크스페이스에 속해있는지 확인
-        if (!userWorkspaceRepository.existsByUserIdAndWorkspaceId(userId, workspaceId))
-            throw new WorkspaceHandler(ErrorStatus.NOT_BELONG_TO_WORKSPACE);
+    public WorkspaceResponseDTO.DocumentSidebarList getDocumentWithoutLastOpenedList(User user, Workspace workspace) {
 
         // 유저가 가장 최근에 조회한 문서 5개 추출
-        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedRepository.findTop5ByWorkspaceIdAndUserIdOrderByLastOpenedDesc(workspaceId, userId);
+        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedRepository.findTop5ByWorkspaceIdAndUserIdOrderByLastOpenedDesc(workspace.getId(), user.getId());
 
         return WorkspaceConverter.toDocumentSidebarList(
                 documentList.stream()
@@ -92,51 +62,27 @@ public class WorkspaceQueryServiceImpl implements WorkspaceQueryService {
     }
 
     @Override
-    public WorkspaceResponseDTO.DocumentCalendarList getDocumentForCalendar(Long userId, Long workspaceId, LocalDate startDate, LocalDate endDate) {
-
-        // 유저 존재 확인
-        userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
-        // workspace 존재 확인
-        workspaceRepository.findById(workspaceId)
-                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
-
-        // 유저가 워크스페이스에 속해있는지 확인
-        if (!userWorkspaceRepository.existsByUserIdAndWorkspaceId(userId, workspaceId))
-            throw new WorkspaceHandler(ErrorStatus.NOT_BELONG_TO_WORKSPACE);
+    public WorkspaceResponseDTO.DocumentCalendarList getDocumentForCalendar(User user, Workspace workspace, LocalDate startDate, LocalDate endDate) {
 
         LocalDateTime startDateTime = startDate.atStartOfDay();
         LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
 
         // 워크스페이스에 속하면서 생성 날짜가 startDate, endDate 사이인 문서 리스트 검색
-        List<Meeting> meetingList = meetingRepository.findAllDocumentForCalendars(workspaceId, startDateTime, endDateTime);
-        List<SnsEvent> snsEventList = snsEventRepository.findAllDocumentForCalendars(workspaceId, startDateTime, endDateTime);
-        List<MoodTracker> moodTrackerList = moodTrackerRepository.findAllDocumentForCalendars(workspaceId, startDateTime, endDateTime);
+        List<Meeting> meetingList = meetingRepository.findAllDocumentForCalendars(workspace, startDateTime, endDateTime);
+        List<SnsEvent> snsEventList = snsEventRepository.findAllDocumentForCalendars(workspace, startDateTime, endDateTime);
+        List<MoodTracker> moodTrackerList = moodTrackerRepository.findAllDocumentForCalendars(workspace, startDateTime, endDateTime);
 
         // 모든 문서 합치기
         return workspaceConverter.toDocumentCalendarList(meetingList, snsEventList, moodTrackerList);
     }
 
     @Override
-    public WorkspaceResponseDTO.WorkspaceEditPage getEditPage(Long userId, Long workspaceId) {
+    public WorkspaceResponseDTO.WorkspaceEditPage getEditPage(User user, Workspace workspace) {
 
-        // 유저 존재 확인
-        userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
-        // workspace 존재 확인
-        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
-                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
-
-        // 유저가 워크스페이스에 속해있는지 확인
-        if (!userWorkspaceRepository.existsByUserIdAndWorkspaceId(userId, workspaceId))
-            throw new WorkspaceHandler(ErrorStatus.NOT_BELONG_TO_WORKSPACE);
-
-        List<UserResponseDTO.MemberInfo> memberInfoList = userWorkspaceRepository.findUsersByWorkspaceId(workspaceId).stream()
+        List<UserResponseDTO.MemberInfo> memberInfoList = userWorkspaceRepository.findUsersByWorkspace(workspace).stream()
                 .map(UserConverter::toMemberInfo)
                 .toList();
 
-        return workspaceConverter.toWorkspaceEditPage(foundWorkspace, memberInfoList);
+        return workspaceConverter.toWorkspaceEditPage(workspace, memberInfoList);
     }
 }

--- a/src/main/java/com/haru/api/global/annotation/AuthUser.java
+++ b/src/main/java/com/haru/api/global/annotation/AuthUser.java
@@ -1,0 +1,11 @@
+package com.haru.api.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUser {
+}

--- a/src/main/java/com/haru/api/global/annotation/AuthUserArgumentResolver.java
+++ b/src/main/java/com/haru/api/global/annotation/AuthUserArgumentResolver.java
@@ -1,0 +1,40 @@
+package com.haru.api.global.annotation;
+
+import com.haru.api.domain.user.entity.User;
+import com.haru.api.domain.user.repository.UserRepository;
+import com.haru.api.domain.user.security.jwt.SecurityUtil;
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthUser.class) &&
+                parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        // 현재 로그인 해 있는 유저 ID 반환
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        // 해당 유저가 존재하는지 확인하고, 존재하면 해당 user 객체 반환
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/haru/api/global/annotation/AuthWorkspace.java
+++ b/src/main/java/com/haru/api/global/annotation/AuthWorkspace.java
@@ -1,0 +1,11 @@
+package com.haru.api.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthWorkspace {
+}

--- a/src/main/java/com/haru/api/global/annotation/AuthWorkspaceArgumentResolver.java
+++ b/src/main/java/com/haru/api/global/annotation/AuthWorkspaceArgumentResolver.java
@@ -1,0 +1,48 @@
+package com.haru.api.global.annotation;
+
+import com.haru.api.domain.workspace.entity.Workspace;
+import com.haru.api.domain.workspace.repository.WorkspaceRepository;
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.WorkspaceHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class AuthWorkspaceArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final WorkspaceRepository workspaceRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthWorkspace.class) &&
+                parameter.getParameterType().equals(Workspace.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        // URL pathVariable에서 workspaceId 추출
+        final Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+
+        if (pathVariables == null) throw new RuntimeException("empty path variables");
+
+        final String workspaceId = pathVariables.get("workspaceId");
+
+        // workspace 존재하는지 확인하고, 존재한다면 해당 workspace 객체 반환
+        return workspaceRepository.findById(Long.parseLong(workspaceId))
+                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/haru/api/global/config/WebConfig.java
+++ b/src/main/java/com/haru/api/global/config/WebConfig.java
@@ -1,12 +1,24 @@
 package com.haru.api.global.config;
 
-import org.springframework.context.annotation.Bean;
+import com.haru.api.global.annotation.AuthUserArgumentResolver;
+import com.haru.api.global.annotation.AuthWorkspaceArgumentResolver;
+import com.haru.api.global.interceptor.WorkspaceMemberAuthInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+    private final AuthWorkspaceArgumentResolver authWorkspaceArgumentResolver;
+    private final WorkspaceMemberAuthInterceptor workspaceMemberAuthInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -15,5 +27,16 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(authUserArgumentResolver);
+        argumentResolvers.add(authWorkspaceArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(workspaceMemberAuthInterceptor);
     }
 }

--- a/src/main/java/com/haru/api/global/interceptor/WorkspaceMemberAuthInterceptor.java
+++ b/src/main/java/com/haru/api/global/interceptor/WorkspaceMemberAuthInterceptor.java
@@ -1,0 +1,73 @@
+package com.haru.api.global.interceptor;
+
+import com.haru.api.domain.user.security.jwt.SecurityUtil;
+import com.haru.api.domain.userWorkspace.repository.UserWorkspaceRepository;
+import com.haru.api.global.annotation.AuthUser;
+import com.haru.api.global.annotation.AuthWorkspace;
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.UserWorkspaceHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class WorkspaceMemberAuthInterceptor implements HandlerInterceptor {
+
+    private final UserWorkspaceRepository userWorkspaceRepository;
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+
+        // 컨트롤러 메서드인지 확인
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+
+        final HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+        // @AuthUser, @AuthWorkspace 어노테이션이 달린 인자가 있는지 확인
+        boolean hasAuthUserParam = false;
+        boolean hasAuthWorkspaceParam = false;
+
+        for (final var param : handlerMethod.getMethodParameters()) {
+            if (param.hasParameterAnnotation(AuthUser.class)) {
+                hasAuthUserParam = true;
+            }
+            if (param.hasParameterAnnotation(AuthWorkspace.class)) {
+                hasAuthWorkspaceParam = true;
+            }
+        }
+
+        // 컨트롤러에 AuthUser, AuthWorkspace 어노테이션이 모두 달린 경우에 해당
+        if(hasAuthUserParam && hasAuthWorkspaceParam) {
+
+            // 1. URL pathVariable에서 workspaceId 추출
+            final Map<String, String> pathVariables =
+                    (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+            final String workspaceId = pathVariables.get("workspaceId");
+
+            if (workspaceId == null) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Workspace ID is missing from path.");
+                return false;
+            }
+
+            // 2. Security Context에서 현재 유저 ID 추출
+            final Long userId = SecurityUtil.getCurrentUserId();
+
+            // 3. 유저가 워크스페이스에 속하는지 확인
+            final boolean isUserInWorkspace = userWorkspaceRepository.existsByUserIdAndWorkspaceId(userId, Long.parseLong(workspaceId));
+
+            // 4. 속하지 않는 경우 예외 발생
+            if(!isUserInWorkspace) throw new UserWorkspaceHandler(ErrorStatus.USER_WORKSPACE_NOT_FOUND);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #190

## 📝작업 내용
> 어노테이션, 인터셉터를 통한 유저, 워크스페이스 검증 자동화

## 🔎코드 설명(스크린샷(선택))
- 컨트롤러에 @AuthUser, @AuthWorkspace가 붙은 user, workspace에 대해서 자동으로 각각의 존재 여부 확인
- 어노테이션이 두 개 다 존재하면 해당 유저가 해당 워크스페이스에 속하는지 확인하는 로직을 인터셉터에서 구현
- 컨트롤러 인자에 어노테이션이 붙은 user, workspace가 유효하다고 검증되면 자동으로 user, workspace 객체를 반환
- 컨트롤러에서 Parameter 어노테이션의 hidden 속성을 붙인 이유는, swagger에서 user, workspace 객체를 인자로 넘겨달라고 인식하기 때문에, 이를 방지하기 위해서 붙인 것
- controller에서는 security context에서 userId를 받아오거나, 넘겨받은 workspaceId를 Long으로 변환하는 과정을 생략 가능
- service에서는 user, workspace를 검증하고, 유저가 워크스페이스에 속하는지 확인하는 로직을 생략할 수 있어, 서비스 코드만 남겨둘 수 있음

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X
