### PR TITLE
feat/#194: SNS 이벤트 참여자, 당첨자 리스트 파일, 썸네일 이미지 S3에 업로드하는 기능 및 리스트 파일 다운로드 기능 구현 방식 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,9 @@ dependencies {
 
 	// Apache POI의 XWPF(XML Word Processing Format)
 	implementation 'org.apache.poi:poi-ooxml:5.2.5'
+
+	//thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 dependencyManagement {

--- a/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
@@ -131,30 +131,30 @@ public class SnsEventController {
                     " 참여자 및 당첨자 리스트 다운로드 API입니다. Header에 access token을 넣고 Path Variable에는 snsEventId를 넣어 요청해주세요. Query String에는 다운로드 형식을 넣어주시고 다운로드 형식이 docx라면 리스트의 HTML을 Request Body에 넣어주세요."
     )
     @PostMapping("/{snsEventId}/list/download")
-    public ResponseEntity<byte[]> downloadList(
+    public ApiResponse<SnsEventResponseDTO.ListDownLoadLinkResponse> downloadList(
             @PathVariable String snsEventId,
             @RequestParam ListType listType,
-            @RequestParam Format format,
-            @RequestBody SnsEventRequestDTO.DownloadListRequest request
+            @RequestParam Format format
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
-        byte[] fileBytes = snsEventCommandService.downloadList(
-                userId,
-                Long.parseLong(snsEventId),
-                listType,
-                format,
-                request
+        return ApiResponse.onSuccess(
+                snsEventCommandService.downloadList(
+                        userId,
+                        Long.parseLong(snsEventId),
+                        listType,
+                        format
+                )
         );
 
-        String listTypefileName = listType == ListType.PARTICIPANT ? "참여자" : "당첨자";
-        String filename = format == Format.PDF ? listTypefileName + ".pdf" : listTypefileName + ".docx";
-        String contentType = format == Format.PDF
-                ? MediaType.APPLICATION_PDF_VALUE
-                : "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
-                .contentType(MediaType.parseMediaType(contentType))
-                .body(fileBytes);
+//        String listTypefileName = listType == ListType.PARTICIPANT ? "참여자" : "당첨자";
+//        String filename = format == Format.PDF ? listTypefileName + ".pdf" : listTypefileName + ".docx";
+//        String contentType = format == Format.PDF
+//                ? MediaType.APPLICATION_PDF_VALUE
+//                : "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+//
+//        return ResponseEntity.ok()
+//                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+//                .contentType(MediaType.parseMediaType(contentType))
+//                .body(fileBytes);
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventRequestDTO.java
@@ -36,12 +36,4 @@ public class SnsEventRequestDTO {
     public static class UpdateSnsEventRequest {
         private String title;
     }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class DownloadListRequest {
-        private String listHtml;
-    }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventResponseDTO.java
@@ -109,4 +109,12 @@ public class SnsEventResponseDTO {
     public static class WinnerResponse {
         private String account;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ListDownLoadLinkResponse {
+        private String downloadLink;
+    }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
@@ -42,6 +42,21 @@ public class SnsEvent extends BaseEntity {
     @JoinColumn(name = "workspace_id")
     private Workspace workspace;
 
+    @Column(columnDefinition = "TEXT")
+    private String keyNameParticipantPdf;
+
+    @Column(columnDefinition = "TEXT")
+    private String keyNameParticipantWord;
+
+    @Column(columnDefinition = "TEXT")
+    private String keyNameWinnerPdf;
+
+    @Column(columnDefinition = "TEXT")
+    private String keyNameWinnerWord;
+
+    @Column(columnDefinition = "TEXT")
+    private String thumbnailKey;
+
     @OneToMany(mappedBy = "snsEvent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Participant> participantList = new ArrayList<>();
 
@@ -58,5 +73,20 @@ public class SnsEvent extends BaseEntity {
 
     public void updateTitle(String title) {
         this.title = title;
+    }
+
+    public void updateKeyNameParticipantPdf(
+            String keyNameParicipantPdf,
+            String keyNameParicipantWord,
+            String keyNameWinnerPdf,
+            String keyNameWinnerWord) {
+        this.keyNameParticipantPdf = keyNameParicipantPdf;
+        this.keyNameParticipantWord = keyNameParicipantWord;
+        this.keyNameWinnerPdf = keyNameWinnerPdf;
+        this.keyNameWinnerWord = keyNameWinnerWord;
+    }
+
+    public void updateThumbnailKey(String thumbnailKey) {
+        this.thumbnailKey = thumbnailKey;
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
@@ -14,5 +14,5 @@ public interface SnsEventCommandService {
 
     void deleteSnsEvent(Long userId, Long snsEventId);
 
-    byte[] downloadList(Long userId, Long snsEventId, ListType listType, Format format, SnsEventRequestDTO.DownloadListRequest request);
+    SnsEventResponseDTO.ListDownLoadLinkResponse downloadList(Long userId, Long snsEventId, ListType listType, Format format);
 }

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -72,6 +72,8 @@ public enum ErrorStatus implements BaseErrorCode {
     SNS_EVENT_INSTAGRAM_ALREADY_LINKED(HttpStatus.BAD_REQUEST, "SNS_EVENT4008", "이미 연동된 인스타그램 계정입니다."),
     SNS_EVENT_WRONG_FORMAT(HttpStatus.BAD_REQUEST, "SNS_EVENT4009", "잘못된 다운로드 파일 형식입니다."),
     SNS_EVENT_DOWNLOAD_LIST_ERROR(HttpStatus.BAD_REQUEST, "SNS_EVENT4010", "리스트 다운로드중 오류가 발생했습니다."),
+    SNS_EVENT_LIST_KEYNAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "SNS_EVENT4011", "리스트 다운로드중 키 이름이 존재하지 않습니다."),
+    SNS_EVENT_WRONG_LIST_TYPE(HttpStatus.BAD_REQUEST, "SNS_EVENT4012", "리스트 다운로드중 잘못된 리스트 타입(참여자, 당첨자)입니다."),
 
     // last opened 관련 에러
     USER_DOCUMENT_LAST_OPENED_NOT_FOUND(HttpStatus.NOT_FOUND, "LASTOPENED4001", "해당 문서에 대한 마지막 조회 데이터가 존재하지 않습니다."),

--- a/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
+++ b/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
@@ -85,6 +85,25 @@ public class AmazonS3Manager{
         return presignedRequest.url().toString();
     }
 
+    // 프론트로 수정한 파일명으로 다운로드 가능한 url을 보내기 위해 사용하는 메서드
+    public String generatePresignedUrlForDownloadPdfAndWord(String keyName, String fileName) {
+        if (keyName == null || keyName.isBlank()) return null;
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(amazonConfig.getBucket())
+                .key(keyName)
+                .responseContentDisposition("attachment; filename=\"" + fileName + "\"") // S3파일(PDF) 링크 클릭 시 즉시 다운가능,파일 다운로드 시 이름 설정
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+        return presignedRequest.url().toString();
+    }
+
     //S3에서 key에 해당하는 파일을 다운로드하여 byte 배열로 반환 -> 썸네일 생성시 활용
     public byte[] downloadFile(String keyName) {
         if (keyName == null || keyName.isBlank()) {

--- a/src/main/resources/templates/sns-event-list-pdf-template.html
+++ b/src/main/resources/templates/sns-event-list-pdf-template.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>SNS 이벤트 PDF 리스트 HTML 템플릿</title>
+    <style>
+        table.sns-table {
+            border-collapse: collapse;
+            font-family: 'NotoSansKR', Arial, sans-serif;
+            width: 668px; /* 고정 너비 668px */
+        }
+        /* 셀 공통 스타일 */
+        .sns-table th,
+        .sns-table td {
+            font-size: 15px;
+            color: #333;
+            padding: 6px 22px 6px 10px;
+        }
+        /* 헤더: 아래로 더 내려오게 → padding-top 증가 */
+        .sns-table th {
+            height: 25px; /* 높이 25px */
+            color: #999;
+            font-size: 13px;
+            font-weight: 400;
+            border-bottom: 1px solid #e5e7eb;
+            padding-bottom: 8px; /* ▼ 추가 여백 */
+            background: #fff;
+        }
+        /* 바디(일반 셀) */
+        .sns-table td {
+            height: 50px; /* 높이 50px */
+            border-bottom: 1px solid #f3f4f6;
+            font-weight: 400; /* 번호와 ID 글씨 굵기 */
+            background: #fff;
+        }
+        /* ID 열: 양 사이즈 큼 */
+        .sns-table .id-col {
+            width: 290px;
+        }
+        /* 번호 열: 폭 좁음 */
+        .sns-table .num-col {
+            width: 44px;
+        }
+        /* ★ 가운데선: 2번째/4번째 헤더, 2번째/4번째 바디 각각에 border-right 지정 */
+        .sns-table th.middle-border,
+        .sns-table td.middle-border {
+            border-right: 1px solid #e5e7eb !important;  /* !important로 확실히 */
+        }
+    </style>
+</head>
+<body style="font-family: 'NotoSansKR', Arial, sans-serif; margin: 24px;">
+<table class="sns-table">
+    <thead>
+    <tr>
+        <th style="min-width:40px; width:50px;">번호</th>
+        <th style="min-width:120px;">ID</th>
+        <th style="min-width:40px; width:50px;">번호</th>
+        <th style="min-width:120px;">ID</th>
+    </tr>
+    </thead>
+    <tbody>
+    <!-- 한 행에 왼쪽리스트와 오른쪽리스트를 쌍으로 출력 -->
+    <tr th:each="leftItem, leftStat : ${leftList}">
+        <td th:text="${leftStat.count}"></td>
+        <td class="id" th:text="${leftItem.nickname}"></td>
+        <td th:text="${#lists.size(rightList) >= leftStat.index + 1 ? leftStat.count + #lists.size(leftList) : ''}"></td>
+        <td class="id" th:text="${#lists.size(rightList) >= leftStat.index + 1 ? rightList[leftStat.index].nickname : ''}"></td>
+    </tr>
+    <!-- 만약 왼쪽 리스트가 더 짧고, 오른쪽 리스트가 더 길 때 추가 행 출력 -->
+    <tr th:each="rightStat : ${#numbers.sequence(leftList.size() + 1, rightList.size())}" th:if="${rightList.size() > leftList.size()}">
+        <td></td>
+        <td class="id"></td>
+        <td th:text="${rightStat + leftList.size() - 1}"></td>
+        <td class="id" th:text="${rightList[rightStat - 1].nickname}"></td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣연관된 이슈
> #194

## 📝작업 내용
> 참여자, 당첨자 리스트 파일(PDF, Word)인 바이트 배열과 썸네일 이미지 S3에 업로드 후 각각의 keyName을 SnsEvent Entity에 저장
> 리스트 파일 바이트 배열로 생성한 방법
- PDF 파일: Thymeleaf 템플릿에 데이터를 바인딩해 HTML로 렌더링 후 PDF로 변환
- Word 파일: 데이터가 포함된 표(Table)를 생성해 저장
> 기존에 리스트 파일을 바이트 배열로 반환하던 방식의 다운로드 기능을 S3에 저장된 파일의 다운로드 URL을 반환하는 방식으로 변경

## 🔎코드 설명(스크린샷(선택))
> x

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
