### PR TITLE
feat/#222: 회의 종료 후 s3에 회의 음성 파일 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,9 @@ dependencies {
 
 	// Apache POI의 XWPF(XML Word Processing Format)
 	implementation 'org.apache.poi:poi-ooxml:5.2.5'
+
+	// audio encoder
+	implementation("ws.schild:jave-all-deps:3.5.0")
 }
 
 dependencyManagement {

--- a/src/main/java/com/haru/api/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/haru/api/domain/meeting/entity/Meeting.java
@@ -52,7 +52,8 @@ public class Meeting extends BaseEntity {
     private LocalDateTime startTime;
 
     // s3 음성 파일 key
-    private String voiceFileKey;
+    @Setter
+    private String audioFileKey;
 
     private Meeting(String title, String agendaResult, User user, Workspace workspace) {
         this.title = title;
@@ -70,7 +71,9 @@ public class Meeting extends BaseEntity {
     public void updateProceeding(String proceeding) {
         this.proceeding = proceeding;
     }
-
+    public void initStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
 
     // 연관관계 편의 메서드
     public void addTag(Keyword keyword) {

--- a/src/main/java/com/haru/api/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/haru/api/domain/meeting/entity/Meeting.java
@@ -8,6 +8,7 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,7 +48,11 @@ public class Meeting extends BaseEntity {
     @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MeetingKeyword> meetingKeywords = new ArrayList<>();
 
+    // 회의 시작 시간
+    private LocalDateTime startTime;
 
+    // s3 음성 파일 key
+    private String voiceFileKey;
 
     private Meeting(String title, String agendaResult, User user, Workspace workspace) {
         this.title = title;

--- a/src/main/java/com/haru/api/infra/mp3encoder/Mp3EncoderService.java
+++ b/src/main/java/com/haru/api/infra/mp3encoder/Mp3EncoderService.java
@@ -1,0 +1,130 @@
+package com.haru.api.infra.mp3encoder;
+
+import org.springframework.stereotype.Service;
+import ws.schild.jave.Encoder;
+import ws.schild.jave.MultimediaObject;
+import ws.schild.jave.encode.AudioAttributes;
+import ws.schild.jave.encode.EncodingAttributes;
+import ws.schild.jave.process.ProcessWrapper;
+import ws.schild.jave.process.ffmpeg.DefaultFFMPEGLocator;
+import ws.schild.jave.process.ffmpeg.FFMPEGProcess;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class Mp3EncoderService {
+
+    /**
+     * Raw PCM 오디오 데이터(byte[])를 MP3 형식으로 인코딩합니다.
+     *
+     * @param pcmData       인코딩할 원본 PCM 데이터
+     * @param channels      오디오 채널 (1: 모노, 2: 스테레오)
+     * @param samplingRate  샘플링 레이트 (e.g., 44100, 16000)
+     * @param bitRate       비트레이트 (e.g., 128000 for 128kbps)
+     * @return 인코딩된 MP3 데이터 byte[]
+     */
+    public byte[] encodePcmToMp3(byte[] pcmData, int channels, int samplingRate, int bitRate) {
+        File sourcePcm = null;
+        File targetMp3 = null;
+
+        try {
+            sourcePcm = File.createTempFile("source_pcm_", ".raw");
+            try (FileOutputStream fos = new FileOutputStream(sourcePcm)) {
+                fos.write(pcmData);
+            }
+
+            targetMp3 = File.createTempFile("target_mp3_", ".mp3");
+
+            AudioAttributes audio = new AudioAttributes();
+            audio.setCodec("libmp3lame");
+            audio.setBitRate(bitRate);
+            audio.setChannels(channels);
+            audio.setSamplingRate(samplingRate);
+
+            EncodingAttributes attrs = new EncodingAttributes();
+            attrs.setOutputFormat("mp3");
+            attrs.setAudioAttributes(audio);
+
+            // Encoder를 생성할 때 커스텀 Locator를 전달합니다.
+            Encoder encoder = new Encoder(new RawAudioLocator(channels, samplingRate));
+
+            // MultimediaObject는 소스 파일만 감쌉니다.
+            encoder.encode(new MultimediaObject(sourcePcm), targetMp3, attrs);
+
+            return Files.readAllBytes(targetMp3.toPath());
+
+        } catch (Exception e) {
+            throw new RuntimeException("MP3 인코딩 실패", e);
+        } finally {
+            if (sourcePcm != null && sourcePcm.exists()) {
+                sourcePcm.delete();
+            }
+            if (targetMp3 != null && targetMp3.exists()) {
+                targetMp3.delete();
+            }
+        }
+    }
+
+    /**
+     * Raw PCM 파일을 디코딩하기 위한 정보를 FFmpeg에 제공하는 private static inner 클래스.
+     * 외부에서는 알 필요 없는 구현 세부사항이므로 내부에 캡슐화합니다.
+     */
+    private static class RawAudioFFMPEGProcess  extends FFMPEGProcess  {
+
+        private final int channels;
+        private final int samplingRate;
+
+        public RawAudioFFMPEGProcess(String executablePath, int channels, int samplingRate) {
+            super(executablePath);
+            this.channels = channels;
+            this.samplingRate = samplingRate;
+        }
+
+        @Override
+        protected Stream<String> enhanceArguments(Stream<String> execArgs) {
+            // Stream을 List로 변환하여 '-i' 인자의 위치를 찾기
+            List<String> args = execArgs.collect(Collectors.toList());
+            int inputIndex = args.indexOf("-i");
+
+            if (inputIndex != -1) {
+                // '-i' 바로 앞에 raw pcm 포맷 정보를 추가
+                List<String> pcmArgs = new ArrayList<>();
+                pcmArgs.add("-f");
+                pcmArgs.add("s16le");
+                pcmArgs.add("-ac");
+                pcmArgs.add(String.valueOf(this.channels));
+                pcmArgs.add("-ar");
+                pcmArgs.add(String.valueOf(this.samplingRate));
+
+                // 원래 리스트의 '-i' 위치에 pcm 관련 인자들을 삽입
+                args.addAll(inputIndex, pcmArgs);
+            }
+
+            // 수정된 List를 다시 Stream으로 변환하여 반환
+            return args.stream();
+        }
+    }
+
+    private static class RawAudioLocator extends DefaultFFMPEGLocator {
+        private final int channels;
+        private final int samplingRate;
+
+        public RawAudioLocator(int channels, int samplingRate) {
+            super();
+            this.channels = channels;
+            this.samplingRate = samplingRate;
+        }
+
+        @Override
+        public ProcessWrapper createExecutor() {
+            // 기본 FFMPEGProcess 대신 직접 구현한 RawAudioFFMPEGProcess를 반환
+            return new RawAudioFFMPEGProcess(this.getExecutablePath(), this.channels, this.samplingRate);
+        }
+    }
+}

--- a/src/main/java/com/haru/api/infra/websocket/AudioSessionBuffer.java
+++ b/src/main/java/com/haru/api/infra/websocket/AudioSessionBuffer.java
@@ -40,8 +40,8 @@ public class AudioSessionBuffer {
         currentUtteranceBuffer.write(chunk, 0, chunk.length);
     }
 
-    public synchronized byte[] getAllBytes() {
-        return fullBuffer.toByteArray();
+    public synchronized ByteArrayOutputStream getAllBytes() {
+        return fullBuffer;
     }
 
     public synchronized byte[] getCurrentUtteranceBuffer() {

--- a/src/main/java/com/haru/api/infra/websocket/AudioWebSocketHandler.java
+++ b/src/main/java/com/haru/api/infra/websocket/AudioWebSocketHandler.java
@@ -10,6 +10,8 @@ import com.haru.api.infra.api.client.FastApiClient;
 import com.haru.api.infra.api.client.ScoringApiClient;
 import com.haru.api.infra.api.repository.AIQuestionRepository;
 import com.haru.api.infra.api.repository.SpeechSegmentRepository;
+import com.haru.api.infra.mp3encoder.Mp3EncoderService;
+import com.haru.api.infra.s3.AmazonS3Manager;
 import com.orctom.vad4j.VAD;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +21,7 @@ import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.BinaryWebSocketHandler;
 
+import java.io.ByteArrayOutputStream;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,6 +46,10 @@ public class AudioWebSocketHandler extends BinaryWebSocketHandler {
 
     private final ObjectMapper objectMapper;
 
+    private final AmazonS3Manager s3Manager;
+
+    private final Mp3EncoderService encoderService;
+
     private final Pattern pathPattern = Pattern.compile("^/ws/audio/(\\w+)$");
 
     @Override
@@ -61,20 +68,60 @@ public class AudioWebSocketHandler extends BinaryWebSocketHandler {
             Meeting foundMeeting = meetingRepository.findById(meetingId)
                             .orElseThrow(() -> new MeetingHandler(ErrorStatus.MEETING_NOT_FOUND));
 
+            // meeting의 회의 시작 시간 기록
+            foundMeeting.initStartTime(LocalDateTime.now());
+
             sessionBuffers.get(session.getId()).setMeeting(foundMeeting);
         } else {
             // 경로가 올바르지 않은 경우 처리
             session.close(CloseStatus.BAD_DATA.withReason("Invalid path"));
         }
-
         System.out.println("WebSocket 연결됨: " + session.getId());
     }
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-        sessionBuffers.remove(session.getId());
-        sessionQueues.remove(session.getId());
-        System.out.println("연결 종료: " + session.getId());
+        String sessionId = session.getId();
+
+        // 1. 해당 세션의 전체 오디어 버퍼 가져오기
+        ByteArrayOutputStream audioBuffer = sessionBuffers.get(sessionId).getAllBytes();
+
+        // 2. 버퍼에 데이터가 있는 지 확인
+        if (audioBuffer != null && audioBuffer.size() > 0) {
+            try {
+                // 3. 원본 오디오 데이터를 byte[]로 변환
+                byte[] rawAudioData = audioBuffer.toByteArray();
+                log.info("세션 ID {}의 오디오 데이터 처리 시작. 원본 크기: {} bytes", sessionId, rawAudioData.length);
+
+                // 4. 클라이언트 오디오 설정에 맞춰 MP3로 인코딩
+                int channels = 1;
+                int samplingRate = 16000; // 16kHz
+                int bitRate = 128000;     // 128kbps
+                byte[] mp3Data = encoderService.encodePcmToMp3(rawAudioData, channels, samplingRate, bitRate);
+                log.info("MP3 인코딩 완료. 인코딩된 크기: {} bytes", mp3Data.length);
+
+                // 5. S3에 저장할 고유한 키를 생성 및 저장 (확장자 .mp3 추가)
+                String keyName = s3Manager.generateKeyName("meeting/recording") + ".mp3";
+
+                // 6. S3에 인코딩된 MP3 파일을 업로드
+                s3Manager.uploadFile(keyName, mp3Data, "audio/mpeg"); // MP3의 MIME 타입은 "audio/mpeg"
+                log.info("S3 업로드 성공. Key: {}", keyName);
+
+                // 7. meeting entity에 audio key name 저장
+                Meeting currentMeeting = sessionBuffers.get(sessionId).getMeeting();
+                currentMeeting.setAudioFileKey(keyName);
+                meetingRepository.save(currentMeeting);
+
+            } catch (Exception e) {
+                log.error("세션 ID {}의 오디오 처리 및 S3 업로드 중 오류 발생", sessionId, e);
+            }
+        } else {
+            log.warn("세션 ID {}에 처리할 오디오 데이터가 없습니다.", sessionId);
+        }
+
+        sessionBuffers.remove(sessionId);
+        sessionQueues.remove(sessionId);
+        log.info("연결 종료: {}", sessionId);
     }
 
     @Override
@@ -108,7 +155,7 @@ public class AudioWebSocketHandler extends BinaryWebSocketHandler {
                     sessionBuffer.setIsTriggered(true);
                     sessionBuffer.resetCurrentUtteranceBuffer();
 
-                    // todo: 음성이 시작된 시간 기록 (완료)
+                    // 발화가 시작된 시간 버퍼에 저장
                     sessionBuffer.setUtteranceStartTime(LocalDateTime.now());
 
                     log.info("isTriggered: {}", sessionBuffer.getIsTriggered());
@@ -133,7 +180,7 @@ public class AudioWebSocketHandler extends BinaryWebSocketHandler {
                     // noVoiceCount 가 임계값에 도달한 경우, 음성의 끝이라고 판단
                     if (sessionBuffer.getNoVoiceCount() >= AudioSessionBuffer.NO_VOICE_COUNT_TARGET) {
 
-                        // 세션별 큐가 없으면 생성
+                        // 세션별 발화를 처리하기 위한 큐가 없으면 생성
                         sessionQueues.computeIfAbsent(sessionId, id ->
                             new AudioProcessingQueue(
                                     fastApiClient::sendRawBytesToFastAPI,
@@ -151,6 +198,7 @@ public class AudioWebSocketHandler extends BinaryWebSocketHandler {
                         sessionQueues.get(sessionId).enqueue(sessionBuffer.getCurrentUtteranceBuffer());
                         log.info("speech detected");
 
+                        // 현재 발화를 처리했으므로, 발화를 임시로 저장해놓는 버퍼 초기화
                         sessionBuffer.resetCurrentUtteranceBuffer();
                         sessionBuffer.setIsTriggered(false);
                     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #211

## 📝작업 내용
> 회의 종료 후 s3에 회의 음성 파일 업로드 기능 구현

## 🔎코드 설명(스크린샷(선택))
- meeting entity에 회의 음성 파일 key name, 회의 시작 시간 컬럼 추가
- 회의 시작(웹소켓 연결)시 회의 시작 시간을 버퍼에 담아두도록 구현
- 회의 종료(웹소켓 연결 끊김)시 전체  회의 음성 파일을 s3에 업로드하고, key name을 meeting entity에 업데이트하고 db에 저장하도록 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X
