### PR TITLE
feat/#213: 회의 종료 후 chatGPT로 AI 회의록 생성 기능 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -21,6 +21,8 @@ import com.haru.api.domain.workspace.repository.WorkspaceRepository;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.*;
 import com.haru.api.infra.api.client.ChatGPTClient;
+import com.haru.api.infra.api.entity.SpeechSegment;
+import com.haru.api.infra.api.repository.SpeechSegmentRepository;
 import com.haru.api.infra.mp3encoder.Mp3EncoderService;
 import com.haru.api.infra.s3.AmazonS3Manager;
 import com.haru.api.infra.websocket.AudioSessionBuffer;
@@ -47,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -62,6 +65,7 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
     private final ChatGPTClient chatGPTClient;
     private final UserDocumentLastOpenedRepository userDocumentLastOpenedRepository;
     private final WebSocketSessionRegistry webSocketSessionRegistry;
+    private final SpeechSegmentRepository speechSegmentRepository;
 
     private final AmazonS3Manager s3Manager;
     private final Mp3EncoderService encoderService;
@@ -263,7 +267,31 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
             // 3. 조회한 엔티티의 상태를 변경합니다.
             currentMeeting.setAudioFileKey(keyName);
 
-            // 4. todo: AI 회의록 생성
+            // 4. AI 회의록 생성
+            List<SpeechSegment> segments = speechSegmentRepository.findByMeeting(currentMeeting);
+
+            if (segments.isEmpty()) {
+                log.warn("meetingId: {}에 대한 대화 내용이 없어 AI 요약을 생략합니다.", currentMeeting.getId());
+                return;
+            }
+
+            // 2. 모든 대화 텍스트를 하나의 문자열로 조합
+            String documentText = segments.stream()
+                    .map(SpeechSegment::getText)
+                    .collect(Collectors.joining("\n"));
+
+            String agendaResult = currentMeeting.getAgendaResult();
+
+            // 동기적 분석 요청
+            String analysisResult = chatGPTClient.analyzeMeetingTranscript(documentText, agendaResult).block();
+
+            // 분석 결과 업데이트
+            if (analysisResult != null && !analysisResult.isBlank()) {
+                currentMeeting.updateProceeding(analysisResult);
+                log.info("meetingId: {}의 AI 회의록 생성 및 저장 완료.", currentMeeting.getId());
+            } else {
+                log.warn("meetingId: {}의 AI 분석 결과가 비어있습니다.", currentMeeting.getId());
+            }
 
         } else {
             log.warn("meetingId: {}에 처리할 오디오 데이터가 없습니다.", currentMeeting.getId());

--- a/src/main/java/com/haru/api/infra/api/client/ChatGPTClient.java
+++ b/src/main/java/com/haru/api/infra/api/client/ChatGPTClient.java
@@ -222,4 +222,42 @@ public class ChatGPTClient {
                 .bodyToMono(OpenAIResponse.class)
                 .map(response -> response.getChoices().get(0).getMessage().getContent());
     }
+
+    public Mono<String> analyzeMeetingTranscript(String documentText, String agendaResult) {
+        if (documentText == null || documentText.isBlank()) {
+            // 분석할 내용이 없으면 미리 정의된 응답을 반환합니다.
+            return Mono.just("분석할 대화 내용이 없습니다.");
+        }
+
+        // 안건 요약과 실제 대화록을 모두 포함하도록 프롬프트 수정
+        String prompt = "다음은 회의 전에 공유된 '안건 요약'과 실제 진행된 '회의 대화록'입니다. 두 내용을 모두 참고하여 다음 세 가지 작업을 수행해주세요.\n\n" +
+                "--- 안건 요약 ---\n" +
+                (agendaResult != null && !agendaResult.isBlank() ? agendaResult : "제공된 안건 요약 없음") + "\n\n" +
+                "--- 회의 대화록 ---\n" +
+                documentText + "\n\n" +
+                "1. 회의의 전체 내용을 3~4 문장으로 요약해주세요.\n" +
+                "2. 논의된 핵심 주제들을 발화 주제와 세부 사항으로 이루어지도록 추출해주세요.\n" +
+                "3. 회의에서 도출된 실행 과제(Action Item)가 있다면 목록으로 정리해주세요. 없다면 응답에 아예 포함하지 마세요.\n" +
+                "반드시 '요약 내용|||핵심 주제1,핵심 주제2|||실행 과제 목록' 형식으로 응답해주세요. 다른 설명은 절대 붙이지 마세요.\n" +
+                "또한, 응답하는 모든 내용은 마크다운(Markdown) 형식으로 작성해주세요. 예를 들어, 실행 과제는 마크다운의 리스트 형식(-)을 사용해주세요.";
+
+        List<Map<String, String>> messages = List.of(
+                Map.of("role", "system", "content", "너는 회의록을 분석하여 요약, 핵심 주제, 실행 과제를 정해진 형식에 따라 추출하는 전문 AI 비서야."),
+                Map.of("role", "user", "content", prompt)
+        );
+
+        Map<String, Object> requestBody = Map.of(
+                "model", "gpt-4o",
+                "messages", messages,
+                "max_tokens", 800 // 응답 길이를 넉넉하게 설정
+        );
+
+        // WebClient를 통해 OpenAI API 호출
+        return webClient.post()
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(OpenAIResponse.class)
+                .map(response -> response.getChoices().get(0).getMessage().getContent());
+    }
+
 }

--- a/src/main/java/com/haru/api/infra/api/repository/SpeechSegmentRepository.java
+++ b/src/main/java/com/haru/api/infra/api/repository/SpeechSegmentRepository.java
@@ -1,7 +1,12 @@
 package com.haru.api.infra.api.repository;
 
+import com.haru.api.domain.meeting.entity.Meeting;
 import com.haru.api.infra.api.entity.SpeechSegment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SpeechSegmentRepository extends JpaRepository<SpeechSegment, Long> {
+    // 특정 Meeting에 속한 모든 SpeechSegment를 조회하는 메서드
+    List<SpeechSegment> findByMeeting(Meeting meeting);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #213 

## 📝작업 내용
> 
- SpeechSegmentRepository에 Meeting에 속한 모든 Segment 조회 메서드 추가
- MeetingService에 STT와 안건지 분석 결과 저장 로직 추가
- ChatGPTClient에 STT 분석 요청 메서드 추가

## 🔎코드 설명(스크린샷(선택))
> 코드에 대한 설명을 작성해주세요.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
