### PR TITLE
fix/#226: 문서 수정, 삭제 시 last opened 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/lastOpened/entity/Documentable.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/Documentable.java
@@ -1,0 +1,10 @@
+package com.haru.api.domain.lastOpened.entity;
+
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
+
+public interface Documentable {
+    Long getId();
+    String getTitle();
+    Long getWorkspaceId();
+    DocumentType getDocumentType();
+}

--- a/src/main/java/com/haru/api/domain/lastOpened/entity/Documentable.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/Documentable.java
@@ -7,4 +7,5 @@ public interface Documentable {
     String getTitle();
     Long getWorkspaceId();
     DocumentType getDocumentType();
+    String getThumbnailKeyName();
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
@@ -2,6 +2,7 @@ package com.haru.api.domain.lastOpened.repository;
 
 import com.haru.api.domain.lastOpened.entity.UserDocumentId;
 import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -20,5 +21,6 @@ public interface UserDocumentLastOpenedRepository extends JpaRepository<UserDocu
             "ORDER BY udlo.lastOpened DESC")
     List<UserDocumentLastOpened> findRecentDocumentsByTitle(Long workspaceId, Long userId, String title);
 
-    List<UserDocumentLastOpened> findById_DocumentId(Long documentId);
+    @Query("SELECT lo FROM UserDocumentLastOpened lo WHERE lo.id.documentId = :documentId AND lo.id.documentType = :documentType")
+    List<UserDocumentLastOpened> findByDocumentIdAndDocumentType(Long documentId, DocumentType documentType);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
@@ -19,4 +19,6 @@ public interface UserDocumentLastOpenedRepository extends JpaRepository<UserDocu
             "AND udlo.title LIKE %:title% " +
             "ORDER BY udlo.lastOpened DESC")
     List<UserDocumentLastOpened> findRecentDocumentsByTitle(Long workspaceId, Long userId, String title);
+
+    List<UserDocumentLastOpened> findById_DocumentId(Long documentId);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
@@ -1,8 +1,14 @@
 package com.haru.api.domain.lastOpened.service;
 
+import com.haru.api.domain.lastOpened.entity.Documentable;
 import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
+import com.haru.api.domain.user.entity.User;
+
+import java.util.List;
 
 public interface UserDocumentLastOpenedService {
 
     void updateLastOpened(Long userId, DocumentType documentType, Long documentId, Long workspaceId, String title);
+
+    void createInitialRecordsForWorkspaceUsers(List<User> usersInWorkspace, Documentable document);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
@@ -11,4 +11,8 @@ public interface UserDocumentLastOpenedService {
     void updateLastOpened(Long userId, DocumentType documentType, Long documentId, Long workspaceId, String title);
 
     void createInitialRecordsForWorkspaceUsers(List<User> usersInWorkspace, Documentable document);
+
+    void deleteRecordsForWorkspaceUsers(Documentable document);
+
+    void updateRecordsForWorkspaceUsers(Documentable document);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
@@ -1,5 +1,6 @@
 package com.haru.api.domain.lastOpened.service;
 
+import com.haru.api.domain.lastOpened.entity.Documentable;
 import com.haru.api.domain.lastOpened.entity.UserDocumentId;
 import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
 import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +40,7 @@ public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpened
                             .user(foundUser)
                             .workspaceId(workspaceId)
                             .title(title)
+                            .lastOpened(null)
                             .build();
                 });
 
@@ -44,6 +48,35 @@ public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpened
         userDocumentLastOpenedRepository.save(record);
 
         log.info("userDocumentLastOpened updated for userId: {}, documentId:{}, workspaceId:{}, title:{}", record.getUser().getId(), record.getId().getDocumentId(), workspaceId, title);
+    }
+
+    public void createInitialRecordsForWorkspaceUsers(List<User> usersInWorkspace, Documentable document) {
+
+        // 저장할 엔티티들을 담을 리스트를 생성
+        List<UserDocumentLastOpened> recordsToSave = new ArrayList<>();
+
+        // 각 유저에 대해 last opened entity를 생성하고 리스트에 추가
+        for (User user : usersInWorkspace) {
+            UserDocumentId documentId = new UserDocumentId(
+                    user.getId(),
+                    document.getId(),
+                    document.getDocumentType()
+            );
+
+            UserDocumentLastOpened newRecord = UserDocumentLastOpened.builder()
+                    .id(documentId)
+                    .user(user)
+                    .title(document.getTitle())
+                    .workspaceId(document.getWorkspaceId())
+                    .lastOpened(null)
+                    .build();
+
+            recordsToSave.add(newRecord);
+        }
+
+        if (!recordsToSave.isEmpty()) {
+            userDocumentLastOpenedRepository.saveAll(recordsToSave);
+        }
     }
 
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
@@ -64,8 +64,8 @@ public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpened
     @Override
     public void deleteRecordsForWorkspaceUsers(Documentable documentable) {
 
-        // 해당 문서 id에 해당하는 last opened 튜플 검색
-        List<UserDocumentLastOpened> recordsToUpdate = userDocumentLastOpenedRepository.findById_DocumentId(documentable.getId());
+        // 해당 문서 id, 문서 타입에 해당하는 last opened 튜플 검색
+        List<UserDocumentLastOpened> recordsToUpdate = userDocumentLastOpenedRepository.findByDocumentIdAndDocumentType(documentable.getId(), documentable.getDocumentType());
 
         if (!recordsToUpdate.isEmpty()) {
             userDocumentLastOpenedRepository.deleteAllInBatch(recordsToUpdate);
@@ -76,8 +76,8 @@ public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpened
     @Override
     public void updateRecordsForWorkspaceUsers(Documentable documentable) {
 
-        // 해당 문서 id에 해당하는 last opened 튜플 검색
-        List<UserDocumentLastOpened> recordsToUpdate = userDocumentLastOpenedRepository.findById_DocumentId(documentable.getId());
+        // 해당 문서 id, 문서 타입에 해당하는 last opened 튜플 검색
+        List<UserDocumentLastOpened> recordsToUpdate = userDocumentLastOpenedRepository.findByDocumentIdAndDocumentType(documentable.getId(), documentable.getDocumentType());
 
         if (!recordsToUpdate.isEmpty()) {
             for (UserDocumentLastOpened record : recordsToUpdate) {

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
@@ -102,6 +102,7 @@ public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpened
                     .user(user)
                     .title(document.getTitle())
                     .workspaceId(document.getWorkspaceId())
+                    .thumbnailKeyName(document.getThumbnailKeyName())
                     .build();
 
             recordsToProcess.add(newRecord);

--- a/src/main/java/com/haru/api/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/haru/api/domain/meeting/entity/Meeting.java
@@ -1,5 +1,7 @@
 package com.haru.api.domain.meeting.entity;
 
+import com.haru.api.domain.lastOpened.entity.Documentable;
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.workspace.entity.Workspace;
 import com.haru.api.global.common.entity.BaseEntity;
@@ -18,7 +20,7 @@ import java.util.List;
 @DynamicUpdate
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Meeting extends BaseEntity {
+public class Meeting extends BaseEntity implements Documentable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -82,5 +84,15 @@ public class Meeting extends BaseEntity {
                 .keyword(keyword)
                 .build();
         this.meetingKeywords.add(meetingKeyword);
+    }
+
+    @Override
+    public Long getWorkspaceId() {
+        return this.workspace.getId();
+    }
+
+    @Override
+    public DocumentType getDocumentType() {
+        return DocumentType.AI_MEETING_MANAGER;
     }
 }

--- a/src/main/java/com/haru/api/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/haru/api/domain/meeting/entity/Meeting.java
@@ -57,6 +57,9 @@ public class Meeting extends BaseEntity implements Documentable {
     @Setter
     private String audioFileKey;
 
+    @Column(columnDefinition = "TEXT")
+    private String thumbnailKeyName;
+
     private Meeting(String title, String agendaResult, User user, Workspace workspace) {
         this.title = title;
         this.agendaResult = agendaResult;
@@ -84,6 +87,10 @@ public class Meeting extends BaseEntity implements Documentable {
                 .keyword(keyword)
                 .build();
         this.meetingKeywords.add(meetingKeyword);
+    }
+
+    public void initThumbnailKey(String thumbnailKey) {
+        this.thumbnailKeyName = thumbnailKey;
     }
 
     @Override

--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -18,7 +18,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Query("SELECT m.workspace FROM Meeting m WHERE m.id = :meetingId")
     Optional<Workspace> findWorkspaceByMeetingId(@Param("meetingId") Long meetingId);
 
-
+    @Query("SELECT m FROM Meeting m WHERE m.workspace.id = :workspaceId")
     List<Meeting> findAllByWorkspaceId(Long workspaceId);
 
     @Query("SELECT mt FROM Meeting mt " +

--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -40,7 +40,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.socket.CloseStatus;
 
-import java.util.Optional;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.*;
@@ -138,26 +137,22 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
     public void updateMeetingTitle(Long userId, Long meetingId, String newTitle) {
 
 
-        Meeting meeting = meetingRepository.findById(meetingId)
+        Meeting foundMeeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new MeetingHandler(ErrorStatus.MEETING_NOT_FOUND));
 
         User foundUser = userRepository.findById(userId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 회의 생성자 권한 확인
-        if (!meeting.getCreator().getId().equals(userId)) {
+        if (!foundMeeting.getCreator().getId().equals(userId)) {
             throw new MemberHandler(ErrorStatus.MEMBER_NO_AUTHORITY);
         }
 
-        meeting.updateTitle(newTitle);
+        foundMeeting.updateTitle(newTitle);
 
-        // last opened title 수정
-        UserDocumentId userDocumentId = new UserDocumentId(userId, meetingId, DocumentType.AI_MEETING_MANAGER);
-
-        UserDocumentLastOpened foundUserDocumentLastOpened = userDocumentLastOpenedRepository.findById(userDocumentId)
-                .orElseThrow(() -> new UserDocumentLastOpenedHandler(ErrorStatus.USER_DOCUMENT_LAST_OPENED_NOT_FOUND));
-
-        foundUserDocumentLastOpened.updateTitle(newTitle);
+        // meeting 수정 시 워크스페이스에 속해있는 모든 유저에 대해
+        // last opened 테이블에서 해당 문서 정보 업데이트
+        userDocumentLastOpenedService.updateRecordsForWorkspaceUsers(foundMeeting);
     }
 
     @Override
@@ -181,13 +176,9 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
 
         meetingRepository.delete(foundMeeting);
 
-        // last opened 테이블 튜플 삭제
-        // last opened가 없어도 오류 X
-        UserDocumentId userDocumentId = new UserDocumentId(userId, meetingId, DocumentType.AI_MEETING_MANAGER);
-
-        Optional<UserDocumentLastOpened> foundUserDocumentLastOpened = userDocumentLastOpenedRepository.findById(userDocumentId);
-
-        foundUserDocumentLastOpened.ifPresent(userDocumentLastOpenedRepository::delete);
+        // meeting 삭제 시 워크스페이스에 속해있는 모든 유저에 대해
+        // last opened 테이블에서 해당 문서 id를 가지고 있는 튜플 모두 삭제
+        userDocumentLastOpenedService.deleteRecordsForWorkspaceUsers(foundMeeting);
     }
 
     @Override

--- a/src/main/java/com/haru/api/domain/moodTracker/entity/MoodTracker.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/entity/MoodTracker.java
@@ -1,5 +1,7 @@
 package com.haru.api.domain.moodTracker.entity;
 
+import com.haru.api.domain.lastOpened.entity.Documentable;
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import com.haru.api.domain.moodTracker.entity.enums.MoodTrackerVisibility;
 import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.workspace.entity.Workspace;
@@ -22,7 +24,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class MoodTracker extends BaseEntity {
+public class MoodTracker extends BaseEntity implements Documentable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 설문ID
@@ -64,4 +66,14 @@ public class MoodTracker extends BaseEntity {
     }
 
     public void createReport(String report) { this.report = report; }
+
+    @Override
+    public Long getWorkspaceId() {
+        return this.getWorkspace().getId();
+    }
+
+    @Override
+    public DocumentType getDocumentType() {
+        return DocumentType.TEAM_MOOD_TRACKER;
+    }
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/entity/MoodTracker.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/entity/MoodTracker.java
@@ -48,6 +48,9 @@ public class MoodTracker extends BaseEntity implements Documentable {
     @Column(name = "due_date")
     private LocalDateTime dueDate; // 마감일
 
+    @Column(columnDefinition = "TEXT")
+    private String thumbnailKeyName;
+
     @Enumerated(EnumType.STRING)
     @Column(length = 10)
     private MoodTrackerVisibility visibility; // 공개범위 (PUBLIC, PRIVATE)
@@ -66,6 +69,10 @@ public class MoodTracker extends BaseEntity implements Documentable {
     }
 
     public void createReport(String report) { this.report = report; }
+
+    public void initThumbnailKey(String thumbnailKey) {
+        this.thumbnailKeyName = thumbnailKey;
+    }
 
     @Override
     public Long getWorkspaceId() {

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 @Repository
 public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> {
+
+    @Query("SELECT m FROM Meeting m WHERE m.workspace.id = :workspaceId")
     List<MoodTracker> findAllByWorkspaceId(Long workspaceId);
   
     @Modifying

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandServiceImpl.java
@@ -1,8 +1,5 @@
 package com.haru.api.domain.moodTracker.service;
 
-import com.haru.api.domain.lastOpened.entity.UserDocumentId;
-import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
-import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import com.haru.api.domain.lastOpened.repository.UserDocumentLastOpenedRepository;
 import com.haru.api.domain.lastOpened.service.UserDocumentLastOpenedService;
 import com.haru.api.domain.moodTracker.converter.MoodTrackerConverter;
@@ -129,13 +126,9 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
 
         foundMoodTracker.updateTitle(request.getTitle());
 
-        // last opened title 수정
-        UserDocumentId userDocumentId = new UserDocumentId(userId, moodTrackerId, DocumentType.TEAM_MOOD_TRACKER);
-
-        UserDocumentLastOpened foundUserDocumentLastOpened = userDocumentLastOpenedRepository.findById(userDocumentId)
-                .orElseThrow(() -> new UserDocumentLastOpenedHandler(ErrorStatus.USER_DOCUMENT_LAST_OPENED_NOT_FOUND));
-
-        foundUserDocumentLastOpened.updateTitle(request.getTitle());
+        // mood tracker 수정 시 워크스페이스에 속해있는 모든 유저에 대해
+        // last opened 테이블에서 해당 문서 정보 업데이트
+        userDocumentLastOpenedService.updateRecordsForWorkspaceUsers(foundMoodTracker);
     }
 
     /**
@@ -165,13 +158,9 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
 
         moodTrackerRepository.delete(foundMoodTracker);
 
-        // last opened 테이블 튜플 삭제
-        // last opened가 없어도 오류 X
-        UserDocumentId userDocumentId = new UserDocumentId(userId, moodTrackerId, DocumentType.TEAM_MOOD_TRACKER);
-
-        Optional<UserDocumentLastOpened> foundUserDocumentLastOpened = userDocumentLastOpenedRepository.findById(userDocumentId);
-
-        foundUserDocumentLastOpened.ifPresent(userDocumentLastOpenedRepository::delete);
+        // meeting 삭제 시 워크스페이스에 속해있는 모든 유저에 대해
+        // last opened 테이블에서 해당 문서 id를 가지고 있는 튜플 모두 삭제
+        userDocumentLastOpenedService.deleteRecordsForWorkspaceUsers(foundMoodTracker);
     }
 
     /**

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandServiceImpl.java
@@ -158,7 +158,7 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
 
         moodTrackerRepository.delete(foundMoodTracker);
 
-        // meeting 삭제 시 워크스페이스에 속해있는 모든 유저에 대해
+        // mood tracker 삭제 시 워크스페이스에 속해있는 모든 유저에 대해
         // last opened 테이블에서 해당 문서 id를 가지고 있는 튜플 모두 삭제
         userDocumentLastOpenedService.deleteRecordsForWorkspaceUsers(foundMoodTracker);
     }

--- a/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
@@ -57,7 +57,7 @@ public class SnsEvent extends BaseEntity implements Documentable {
     private String keyNameWinnerWord;
 
     @Column(columnDefinition = "TEXT")
-    private String thumbnailKey;
+    private String thumbnailKeyName;
 
     @OneToMany(mappedBy = "snsEvent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Participant> participantList = new ArrayList<>();
@@ -88,8 +88,8 @@ public class SnsEvent extends BaseEntity implements Documentable {
         this.keyNameWinnerWord = keyNameWinnerWord;
     }
 
-    public void updateThumbnailKey(String thumbnailKey) {
-        this.thumbnailKey = thumbnailKey;
+    public void initThumbnailKey(String thumbnailKey) {
+        this.thumbnailKeyName = thumbnailKey;
     }
 
     @Override

--- a/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
@@ -88,7 +88,7 @@ public class SnsEvent extends BaseEntity implements Documentable {
         this.keyNameWinnerWord = keyNameWinnerWord;
     }
 
-    public void initThumbnailKey(String thumbnailKey) {
+    public void initThumbnailKeyName(String thumbnailKey) {
         this.thumbnailKeyName = thumbnailKey;
     }
 

--- a/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
@@ -1,5 +1,7 @@
 package com.haru.api.domain.snsEvent.entity;
 
+import com.haru.api.domain.lastOpened.entity.Documentable;
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.workspace.entity.Workspace;
 import com.haru.api.global.common.entity.BaseEntity;
@@ -19,7 +21,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class SnsEvent extends BaseEntity {
+public class SnsEvent extends BaseEntity implements Documentable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,5 +60,15 @@ public class SnsEvent extends BaseEntity {
 
     public void updateTitle(String title) {
         this.title = title;
+    }
+
+    @Override
+    public Long getWorkspaceId() {
+        return this.workspace.getId();
+    }
+
+    @Override
+    public DocumentType getDocumentType() {
+        return DocumentType.SNS_EVENT_ASSISTANT;
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/entity/SnsEvent.java
@@ -44,6 +44,21 @@ public class SnsEvent extends BaseEntity implements Documentable {
     @JoinColumn(name = "workspace_id")
     private Workspace workspace;
 
+    @Column(columnDefinition = "TEXT")
+    private String keyNameParticipantPdf;
+
+    @Column(columnDefinition = "TEXT")
+    private String keyNameParticipantWord;
+
+    @Column(columnDefinition = "TEXT")
+    private String keyNameWinnerPdf;
+
+    @Column(columnDefinition = "TEXT")
+    private String keyNameWinnerWord;
+
+    @Column(columnDefinition = "TEXT")
+    private String thumbnailKey;
+
     @OneToMany(mappedBy = "snsEvent", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Participant> participantList = new ArrayList<>();
 
@@ -60,6 +75,21 @@ public class SnsEvent extends BaseEntity implements Documentable {
 
     public void updateTitle(String title) {
         this.title = title;
+    }
+
+    public void updateKeyNameParticipantPdf(
+            String keyNameParticipantPdf,
+            String keyNameParicipantWord,
+            String keyNameWinnerPdf,
+            String keyNameWinnerWord) {
+        this.keyNameParticipantPdf = keyNameParticipantPdf;
+        this.keyNameParticipantWord = keyNameParicipantWord;
+        this.keyNameWinnerPdf = keyNameWinnerPdf;
+        this.keyNameWinnerWord = keyNameWinnerWord;
+    }
+
+    public void updateThumbnailKey(String thumbnailKey) {
+        this.thumbnailKey = thumbnailKey;
     }
 
     @Override

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Repository
 public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
 
+    @Query("SELECT m FROM SnsEvent m WHERE m.workspace.id = :workspaceId")
     List<SnsEvent> findAllByWorkspaceId(Long workspaceId);
 
     List<SnsEvent> findAllByWorkspace(Workspace foundWorkspace);

--- a/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
@@ -36,6 +36,6 @@ public interface UserWorkspaceRepository extends JpaRepository<UserWorkspace, Lo
 
     Optional<UserWorkspace> findByWorkspaceAndAuth(Workspace workspace, Auth auth);
 
-    @Query("SELECT uw.user FROM UserWorkspace uw WHERE uw.workspace = :workspace")
-    List<User> findUsersByWorkspace(Workspace workspace);
+    @Query("SELECT uw.user FROM UserWorkspace uw WHERE uw.workspace.id = :workspaceId")
+    List<User> findUsersByWorkspaceId(Long workspaceId);
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryServiceImpl.java
@@ -84,7 +84,7 @@ public class WorkspaceQueryServiceImpl implements WorkspaceQueryService {
     @Override
     public WorkspaceResponseDTO.WorkspaceEditPage getEditPage(User user, Workspace workspace) {
 
-        List<UserResponseDTO.MemberInfo> memberInfoList = userWorkspaceRepository.findUsersByWorkspace(workspace).stream()
+        List<UserResponseDTO.MemberInfo> memberInfoList = userWorkspaceRepository.findUsersByWorkspaceId(workspace.getId()).stream()
                 .map(UserConverter::toMemberInfo)
                 .toList();
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #226

## 📝작업 내용
> 문서 수정, 삭제 시 last opened 업데이트 로직 수정

## 🔎코드 설명(스크린샷(선택))
- 문서 삭제 시, last opened 테이블에서 해당 문서 id를 가지고 있는 모든 튜플을 삭제하도록 수정
- 문서 수정 시, last opened 테이블에서 해당 문서 id를 가지고 있는 모든 튜플의 제목을 수정하도록 수정
- meeting, sns event, mood tracker를 Documentable 인터페이스를 implement 하도록 하여 추상화
- last opened entity에 thumbnailKeyName 필드 추가

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X