### PR TITLE
feat/#101 분위기 트래커 다운로드 API & #219 파일 및 썸네일 생성

### DIFF
--- a/src/main/java/com/haru/api/domain/moodTracker/controller/MoodTrackerController.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/controller/MoodTrackerController.java
@@ -4,6 +4,7 @@ import com.haru.api.domain.moodTracker.dto.MoodTrackerRequestDTO;
 import com.haru.api.domain.moodTracker.dto.MoodTrackerResponseDTO;
 import com.haru.api.domain.moodTracker.service.MoodTrackerCommandService;
 import com.haru.api.domain.moodTracker.service.MoodTrackerQueryService;
+import com.haru.api.domain.snsEvent.entity.enums.Format;
 import com.haru.api.domain.user.security.jwt.SecurityUtil;
 import com.haru.api.global.apiPayload.code.status.SuccessStatus;
 import com.haru.api.global.util.HashIdUtil;
@@ -15,8 +16,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Validated
 @RestController
@@ -133,22 +132,6 @@ public class MoodTrackerController {
         return ApiResponse.of(SuccessStatus.MOOD_TRACKER_ANSWER_SUBMIT, null);
     }
 
-    @PostMapping("/{mood-tracker-hashed-Id}/report-test")
-    @Operation(
-            summary = "분위기 트래커 설문 리포트 즉시 생성 테스트 API",
-            description = "# [v1.0 (2025-07-26)](https://www.notion.so/23f5da7802c58080b4a5e6d24b47d924) 해당 ID의 분위기 트래커 설문 리포트를 즉시 생성합니다."
-    )
-    @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
-    })
-    public  ApiResponse<Void> generateMoodTrackerReportTest (
-            @PathVariable("mood-tracker-hashed-Id") String moodTrackerHashedId
-    ) {
-        Long moodTrackerId = hashIdUtil.decode(moodTrackerHashedId);
-        moodTrackerCommandService.generateReportTest(moodTrackerId);
-        return ApiResponse.of(SuccessStatus._OK, null);
-    }
-
     @GetMapping("/{mood-tracker-hashed-Id}/questions")
     @Operation(
             summary = "분위기 트래커 설문 문항 조회 API",
@@ -198,5 +181,55 @@ public class MoodTrackerController {
         Long moodTrackerId = hashIdUtil.decode(moodTrackerHashedId);
         MoodTrackerResponseDTO.ResponseResult result = moodTrackerQueryService.getResponseResult(userId, moodTrackerId);
         return ApiResponse.onSuccess(result);
+    }
+
+    @GetMapping("/{mood-tracker-hashed-Id}/download")
+    @Operation(
+            summary = "분위기 트래커 설문 리포트 다운로드 API",
+            description = "# [v1.0 (2025-08-13)](https://www.notion.so/2265da7802c580e3b53ddd8d181922b1) 분위기 트래커(moodTrackerId)에 대한 개별 리포트 다운로드 링크를 조회합니다."
+    )
+    @Parameters({
+            @Parameter(name = "mood-tracker-hashed-Id", description = "분위기 트래커 ID (Hashed, Path Variable)", required = true)
+    })
+    public ApiResponse<MoodTrackerResponseDTO.ReportDownLoadLinkResponse> downloadList(
+            @PathVariable(name = "mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @RequestParam Format format
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        Long moodTrackerId = hashIdUtil.decode(moodTrackerHashedId);
+        MoodTrackerResponseDTO.ReportDownLoadLinkResponse result = moodTrackerCommandService.getDownloadLink(userId, moodTrackerId, format);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @PostMapping("/{mood-tracker-hashed-Id}/report-test")
+    @Operation(
+            summary = "분위기 트래커 설문 리포트 즉시 생성 테스트 API",
+            description = "# [v1.0 (2025-07-26)](https://www.notion.so/23f5da7802c58080b4a5e6d24b47d924) 해당 ID의 분위기 트래커 설문 리포트를 즉시 생성합니다."
+    )
+    @Parameters({
+            @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
+    })
+    public  ApiResponse<Void> generateMoodTrackerReportTest (
+            @PathVariable("mood-tracker-hashed-Id") String moodTrackerHashedId
+    ) {
+        Long moodTrackerId = hashIdUtil.decode(moodTrackerHashedId);
+        moodTrackerCommandService.generateReportTest(moodTrackerId);
+        return ApiResponse.of(SuccessStatus._OK, null);
+    }
+
+    @PostMapping("/{mood-tracker-hashed-Id}/report-file-thumbnail-test")
+    @Operation(
+            summary = "분위기 트래커 설문 리포트, 파일, 썸네일 즉시 생성 테스트 API",
+            description = "# [v1.0 (2025-08-14)](https://www.notion.so/24f5da7802c58019a1f7d9c8e882226e) 해당 ID의 분위기 트래커 설문 리포트를 즉시 생성합니다."
+    )
+    @Parameters({
+            @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
+    })
+    public  ApiResponse<Void> generateMoodTrackerReportFileAndThumbnailTest (
+            @PathVariable("mood-tracker-hashed-Id") String moodTrackerHashedId
+    ) {
+        Long moodTrackerId = hashIdUtil.decode(moodTrackerHashedId);
+        moodTrackerCommandService.generateReportFileAndThumbnailTest(moodTrackerId);
+        return ApiResponse.of(SuccessStatus._OK, null);
     }
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/dto/MoodTrackerResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/dto/MoodTrackerResponseDTO.java
@@ -142,4 +142,10 @@ public class MoodTrackerResponseDTO {
         private String content;
         private Integer selectedNum;
     }
+
+    @Getter
+    @Builder
+    public static class ReportDownLoadLinkResponse {
+        private String downloadLink;
+    }
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/entity/MoodTracker.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/entity/MoodTracker.java
@@ -56,6 +56,15 @@ public class MoodTracker extends BaseEntity {
     @Min(0)
     private Integer respondentsNum; // 답변자 수
 
+    @Column(columnDefinition = "TEXT")
+    private String pdfReportKey;
+
+    @Column(columnDefinition = "TEXT")
+    private String wordReportKey;
+
+    @Column(columnDefinition = "TEXT")
+    private String thumbnailKey;
+
     @OneToMany(mappedBy = "moodTracker", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SurveyQuestion> surveyQuestionList = new ArrayList<>();
 
@@ -64,4 +73,16 @@ public class MoodTracker extends BaseEntity {
     }
 
     public void createReport(String report) { this.report = report; }
+
+    public void updateReportKeyName(
+            String pdfReportKey,
+            String wordReportKey
+            ) {
+        this.pdfReportKey = pdfReportKey;
+        this.wordReportKey = wordReportKey;
+    }
+
+    public void updateThumbnailKey(String thumbnailKey) {
+        this.thumbnailKey = thumbnailKey;
+    }
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandService.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandService.java
@@ -2,6 +2,7 @@ package com.haru.api.domain.moodTracker.service;
 
 import com.haru.api.domain.moodTracker.dto.MoodTrackerRequestDTO;
 import com.haru.api.domain.moodTracker.dto.MoodTrackerResponseDTO;
+import com.haru.api.domain.snsEvent.entity.enums.Format;
 
 public interface MoodTrackerCommandService {
     MoodTrackerResponseDTO.CreateResult create(
@@ -25,7 +26,15 @@ public interface MoodTrackerCommandService {
             Long moodTrackerId,
             MoodTrackerRequestDTO.SurveyAnswerList request
     );
+    MoodTrackerResponseDTO.ReportDownLoadLinkResponse getDownloadLink(
+            Long userId,
+            Long moodTrackerId,
+            Format format
+    );
     void generateReportTest(
+            Long moodTrackerId
+    );
+    void generateReportFileAndThumbnailTest(
             Long moodTrackerId
     );
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandServiceImpl.java
@@ -8,7 +8,9 @@ import com.haru.api.domain.moodTracker.converter.MoodTrackerConverter;
 import com.haru.api.domain.moodTracker.dto.MoodTrackerRequestDTO;
 import com.haru.api.domain.moodTracker.dto.MoodTrackerResponseDTO;
 import com.haru.api.domain.moodTracker.entity.*;
+import com.haru.api.domain.moodTracker.entity.enums.MoodTrackerVisibility;
 import com.haru.api.domain.moodTracker.repository.*;
+import com.haru.api.domain.snsEvent.entity.enums.Format;
 import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.user.repository.UserRepository;
 import com.haru.api.domain.userWorkspace.entity.UserWorkspace;
@@ -20,15 +22,20 @@ import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.*;
 import com.haru.api.global.util.HashIdUtil;
 import com.haru.api.infra.redis.RedisReportProducer;
+import com.haru.api.infra.s3.AmazonS3Manager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.haru.api.domain.moodTracker.entity.enums.QuestionType.*;
+import static com.haru.api.global.apiPayload.code.status.ErrorStatus.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -56,17 +63,20 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
 
     private final UserDocumentLastOpenedRepository userDocumentLastOpenedRepository;
 
+    private final AmazonS3Manager amazonS3Manager;
+
     /**
      * 분위기 트래커 생성
      */
     @Override
+    @Transactional
     public MoodTrackerResponseDTO.CreateResult create(
             Long userId,
             Long workspaceId,
             MoodTrackerRequestDTO.CreateRequest request
     ) {
         User foundUser = userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
 
         Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
                 .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
@@ -114,12 +124,13 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
      * 분위기 트래커 제목 수정
      */
     @Override
+    @Transactional
     public void updateTitle(Long userId,
                             Long moodTrackerId,
                             MoodTrackerRequestDTO.UpdateTitleRequest request
     ) {
         User foundUser = userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
 
         MoodTracker foundMoodTracker = moodTrackerRepository.findById(moodTrackerId)
                 .orElseThrow(() -> new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FOUND));
@@ -150,12 +161,13 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
      * 분위기 트래커 삭제
      */
     @Override
+    @Transactional
     public void delete(
             Long userId,
             Long moodTrackerId
     ) {
         User foundUser = userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
 
         MoodTracker foundMoodTracker = moodTrackerRepository.findById(moodTrackerId)
                 .orElseThrow(() -> new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FOUND));
@@ -186,6 +198,7 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
      * 분위기 트래커 설문 링크 메일 전송
      */
     @Override
+    @Transactional
     public void sendSurveyLink(
             Long moodTrackerId
     ) {
@@ -205,6 +218,7 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
      * 분위기 트래커 답변 제출
      */
     @Override
+    @Transactional
     public void submitSurveyAnswers(
             Long moodTrackerId,
             MoodTrackerRequestDTO.SurveyAnswerList request
@@ -274,13 +288,55 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
         moodTrackerRepository.addRespondentsNum(moodTrackerId);
     }
 
-    /**
-     * 분위기 트래커 리포트 생성 테스트
-     */
     @Override
+    @Transactional
+    public MoodTrackerResponseDTO.ReportDownLoadLinkResponse getDownloadLink(
+            Long userId,
+            Long moodTrackerId,
+            Format format
+    ) {
+        MoodTracker foundMoodTracker = moodTrackerRepository.findById(moodTrackerId)
+                .orElseThrow(() -> new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FOUND));
+
+        // 권한 확인
+        UserWorkspace userWorkspace = userWorkspaceRepository.findByWorkspaceIdAndUserId(
+                foundMoodTracker.getWorkspace().getId(), userId
+        ).orElseThrow(() -> new UserWorkspaceHandler(ErrorStatus.USER_WORKSPACE_NOT_FOUND));
+
+        boolean hasAccess =
+                userWorkspace.getAuth().equals(Auth.ADMIN) ||
+                        foundMoodTracker.getCreator().getId().equals(userId) ||
+                        foundMoodTracker.getVisibility().equals(MoodTrackerVisibility.PUBLIC);
+
+        if (!hasAccess) {
+            throw new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_ACCESS_DENIED);
+        }
+
+        // 마감 여부 확인
+        if (LocalDateTime.now().isBefore(foundMoodTracker.getDueDate())) {
+            throw new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FINISHED);
+        }
+
+        String generatedReportUrl = moodTrackerReportService.generateDownloadLink(foundMoodTracker, format);
+
+        return MoodTrackerResponseDTO.ReportDownLoadLinkResponse.builder()
+                .downloadLink(generatedReportUrl)
+                .build();
+    }
+
+    @Override
+    @Transactional
     public void generateReportTest(
             Long moodTrackerId
     ) {
         moodTrackerReportService.generateReport(moodTrackerId);
+    }
+
+    @Override
+    @Transactional
+    public void generateReportFileAndThumbnailTest(
+            Long moodTrackerId
+    ) {
+        moodTrackerReportService.generateAndUploadReportFileAndThumbnail(moodTrackerId);
     }
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerReportService.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerReportService.java
@@ -1,5 +1,16 @@
 package com.haru.api.domain.moodTracker.service;
 
+import com.haru.api.domain.moodTracker.dto.MoodTrackerResponseDTO;
+import com.haru.api.domain.moodTracker.entity.MoodTracker;
+import com.haru.api.domain.snsEvent.entity.enums.Format;
+
 public interface MoodTrackerReportService {
     void generateReport(Long moodTrackerId);
+    void generateAndUploadReportFileAndThumbnail(
+            Long moodTrackerId
+    );
+    String generateDownloadLink(
+            MoodTracker moodTracker,
+            Format format
+    );
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerReportServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerReportServiceImpl.java
@@ -1,18 +1,37 @@
 package com.haru.api.domain.moodTracker.service;
 
+import com.haru.api.domain.snsEvent.entity.enums.Format;
 import com.haru.api.infra.api.dto.SurveyReportResponse;
 import com.haru.api.domain.moodTracker.entity.*;
 import com.haru.api.domain.moodTracker.repository.*;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MoodTrackerHandler;
 import com.haru.api.infra.api.client.ChatGPTClient;
+import com.haru.api.infra.s3.AmazonS3Manager;
+import com.haru.api.infra.s3.MarkdownFileUploader;
+import com.lowagie.text.pdf.BaseFont;
+import com.lowagie.text.pdf.PdfWriter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import com.lowagie.text.Document;
+import com.lowagie.text.Font;
+import com.lowagie.text.Paragraph;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.haru.api.global.apiPayload.code.status.ErrorStatus.*;
+import static com.haru.api.global.apiPayload.code.status.ErrorStatus.MOOD_TRACKER_DOWNLOAD_ERROR;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +44,9 @@ public class MoodTrackerReportServiceImpl implements MoodTrackerReportService {
     private final SubjectiveAnswerRepository subjectiveAnswerRepository;
     private final MultipleChoiceAnswerRepository multipleChoiceAnswerRepository;
     private final CheckboxChoiceAnswerRepository checkboxChoiceAnswerRepository;
+
+    private final AmazonS3Manager amazonS3Manager;
+    private final MarkdownFileUploader markdownFileUploader;
 
     @Async
     public void generateReport(Long moodTrackerId) {
@@ -90,6 +112,8 @@ public class MoodTrackerReportServiceImpl implements MoodTrackerReportService {
         }
 
         moodTrackerRepository.save(foundMoodTracker);
+
+
     }
 
     private String buildPrompt(String title,
@@ -146,5 +170,125 @@ public class MoodTrackerReportServiceImpl implements MoodTrackerReportService {
         }
 
         return sb.toString();
+    }
+
+    @Override
+    public String generateDownloadLink(
+            MoodTracker moodTracker,
+            Format format
+    ) {
+        String downloadLink = "";
+
+        String moodTrackerTitle = moodTracker.getTitle();
+
+        if (format == Format.PDF) {
+            String keyName = moodTracker.getPdfReportKey();
+            if (keyName == null || keyName.isEmpty()) {
+                throw new MoodTrackerHandler(MOOD_TRACKER_KEYNAME_NOT_FOUND);
+            }
+            downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, moodTrackerTitle + "_리포트.pdf");
+        } else if (format == Format.DOCX) {
+            String keyName = moodTracker.getWordReportKey();
+            if (keyName == null || keyName.isEmpty()) {
+                throw new MoodTrackerHandler(MOOD_TRACKER_KEYNAME_NOT_FOUND);
+            }
+            downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, moodTrackerTitle + "_리포트.docx");
+        } else {
+            throw new MoodTrackerHandler(MOOD_TRACKER_WRONG_FORMAT);
+        }
+
+        return downloadLink;
+    }
+
+    @Override
+    public void generateAndUploadReportFileAndThumbnail(Long moodTrackerId){
+
+        // 리포트 생성
+        generateReport(moodTrackerId);
+
+        MoodTracker foundMoodTracker = moodTrackerRepository.findById(moodTrackerId)
+                .orElseThrow(() -> new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FOUND));
+
+        byte[] pdfReportBytes;
+        byte[] docxReportBytes;
+        try {
+            // 폰트 경로
+            URL resource = getClass().getClassLoader().getResource("templates/NotoSansKR-Regular.ttf");
+            File reg = new File(resource.toURI());
+            try (ByteArrayOutputStream pdfOut = new ByteArrayOutputStream()) {
+                Document document = new Document();
+                PdfWriter.getInstance(document, pdfOut);
+                document.open();
+
+                // 한글 폰트 지정
+                BaseFont baseFont = BaseFont.createFont(reg.getAbsolutePath(), BaseFont.IDENTITY_H, BaseFont.EMBEDDED);
+                Font font = new Font(baseFont, 12);
+
+                document.add(new Paragraph("Mood Tracker Report", font));
+                document.add(new Paragraph("제목: " + foundMoodTracker.getTitle(), font));
+                document.add(new Paragraph("작성자: " + foundMoodTracker.getCreator().getName(), font));
+                document.add(new Paragraph("마감일: " + foundMoodTracker.getDueDate(), font));
+                document.add(new Paragraph("리포트 내용: " + foundMoodTracker.getReport(), font));
+
+                document.close();
+                pdfReportBytes = pdfOut.toByteArray();
+            }
+
+            // ====== DOCX 생성 (Apache POI) ======
+            try (ByteArrayOutputStream docxOut = new ByteArrayOutputStream()) {
+                XWPFDocument doc = new XWPFDocument();
+
+                // 제목
+                XWPFParagraph titlePara = doc.createParagraph();
+                XWPFRun titleRun = titlePara.createRun();
+                titleRun.setText("Mood Tracker Report");
+                titleRun.setBold(true);
+                titleRun.setFontFamily("Noto Sans KR");
+                titleRun.setFontSize(14);
+
+                // 내용
+                XWPFParagraph contentPara = doc.createParagraph();
+                XWPFRun contentRun = contentPara.createRun();
+                contentRun.setText("제목: " + foundMoodTracker.getTitle());
+                contentRun.addBreak();
+                contentRun.setText("작성자: " + foundMoodTracker.getCreator().getName());
+                contentRun.addBreak();
+                contentRun.setText("마감일: " + foundMoodTracker.getDueDate());
+                contentRun.addBreak();
+                contentRun.setText("리포트 내용: " + foundMoodTracker.getReport());
+
+                doc.write(docxOut);
+                docxReportBytes = docxOut.toByteArray();
+            }
+
+        } catch (Exception e) {
+            log.error("Error creating document: {}", e.getMessage());
+            throw new MoodTrackerHandler(MOOD_TRACKER_DOWNLOAD_ERROR);
+        }
+        // PDF, DOCS파일, 썸네일 S3에 업로드 및 DB에 keyName저장
+        String fullPath = "mood-tracker/" + moodTrackerId;
+        String pdfReportKey = amazonS3Manager.generateKeyName(fullPath) + "." + "pdf";
+        String wordReportKey = amazonS3Manager.generateKeyName(fullPath) + "." + "docx";
+        amazonS3Manager.uploadFile(pdfReportKey, pdfReportBytes, "application/pdf");
+        amazonS3Manager.uploadFile(wordReportKey, docxReportBytes, "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        // 분위기 트래커에 keyName 저장
+        foundMoodTracker.updateReportKeyName(
+                pdfReportKey,
+                wordReportKey
+        );
+        // 분위기 트래커 리포트의 PDF 첫페이지를 썸네일로 저장
+        String thumbnailKey = markdownFileUploader.createOrUpdateThumbnailWithPdfBytes(
+                pdfReportBytes,
+                "mood-tracker",
+                null
+        );
+        foundMoodTracker.updateThumbnailKey(thumbnailKey);
+    }
+
+    // 파일명 인코딩
+    private String buildEncodedContentDisposition(String originalFilename) {
+        String encodedFilename = URLEncoder.encode(originalFilename, StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20"); // 공백 처리
+        return "attachment; filename*=UTF-8''" + encodedFilename;
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
@@ -270,7 +270,7 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
                 keyNameWinnerWord
         );
         // SNS 이벤트 당첨자 PDF의 첫페이지 썸네일로 저장
-        String thumbnailKey = markdownFileUploader.createOrUpdateThumbnailForSnsEvent(
+        String thumbnailKey = markdownFileUploader.createOrUpdateThumbnailWithPdfBytes(
                 pdfBytesWinner,
                 "sns-event",
                 null

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -57,6 +57,9 @@ public enum ErrorStatus implements BaseErrorCode {
     SURVEY_ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "MOODTRACKER4004", "분위기 트래커 설문의 필수 응답이 누락되었습니다."),
     MOOD_TRACKER_NOT_FINISHED(HttpStatus.BAD_REQUEST, "MOODTRACKER4005", "분위기 트래커 설문 마감일 전입니다."),
     MOOD_TRACKER_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "MOODTRACKER4006", "분위기 트래커 조회 권한이 없습니다."),
+    MOOD_TRACKER_WRONG_FORMAT(HttpStatus.BAD_REQUEST, "MOODTRACKER4007", "분위기 트래커의 잘못된 다운로드 파일 형식입니다."),
+    MOOD_TRACKER_DOWNLOAD_ERROR(HttpStatus.BAD_REQUEST, "MOODTRACKER4008", "분위기 트래커 다운로드중 오류가 발생했습니다."),
+    MOOD_TRACKER_KEYNAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "MOODTRACKER4009", "분위기 트래커 다운로드중 키 이름이 존재하지 않습니다."),
 
     // 메일 관련 에러
     MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "MAIL500", "이메일 전송에 실패했습니다."),

--- a/src/main/java/com/haru/api/infra/redis/RedisReportConsumer.java
+++ b/src/main/java/com/haru/api/infra/redis/RedisReportConsumer.java
@@ -1,6 +1,7 @@
 package com.haru.api.infra.redis;
 
 import com.haru.api.domain.moodTracker.service.MoodTrackerReportService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -21,6 +22,7 @@ public class RedisReportConsumer {
     private static final String QUEUE_KEY = "MOOD_TRACKER_REPORT_GPT_QUEUE";
     private static final long BATCH_SIZE = 20;
 
+    @Transactional
     @Scheduled(cron = "0 0/30 * * * *") // 매시 0분, 30분 실행
     public void pollQueueEvery30Minutes() {
         long now = Instant.now().getEpochSecond();
@@ -32,7 +34,8 @@ public class RedisReportConsumer {
 
         for (String moodTrackerId : dueIds) {
             try {
-                moodTrackerReportService.generateReport(Long.parseLong(moodTrackerId));
+                // PDF, DOCX파일 바이트 배열로 생성 및 썸네일 생성 & 업로드 / DB에 keyName저장
+                moodTrackerReportService.generateAndUploadReportFileAndThumbnail(Long.parseLong(moodTrackerId));
                 redisTemplate.opsForZSet().remove(QUEUE_KEY, moodTrackerId);
             } catch (Exception e) {
                 log.error("GPT 리포트 생성 실패: {}", moodTrackerId, e);

--- a/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
+++ b/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
@@ -14,6 +14,9 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.UUID;
 
@@ -89,10 +92,15 @@ public class AmazonS3Manager{
     public String generatePresignedUrlForDownloadPdfAndWord(String keyName, String fileName) {
         if (keyName == null || keyName.isBlank()) return null;
 
+        // RFC 5987 인코딩
+        String encodedFilename = URLEncoder.encode(fileName, StandardCharsets.UTF_8)
+                .replace("+", "%20"); // 공백 처리
+        String contentDisposition = "attachment; filename*=UTF-8''" + encodedFilename;
+
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(amazonConfig.getBucket())
                 .key(keyName)
-                .responseContentDisposition("attachment; filename=\"" + fileName + "\"") // S3파일(PDF) 링크 클릭 시 즉시 다운가능,파일 다운로드 시 이름 설정
+                .responseContentDisposition(contentDisposition)
                 .build();
 
         GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()

--- a/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
+++ b/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.UUID;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -84,7 +82,7 @@ public class MarkdownFileUploader {
         return thumbnailKeyToUse;
     }
 
-    public String createOrUpdateThumbnailForSnsEvent(byte[] pdfBytes, String featurePath, String existingThumbnailKey) {
+    public String createOrUpdateThumbnailWithPdfBytes(byte[] pdfBytes, String featurePath, String existingThumbnailKey) {
         // 1. 다운로드한 PDF로 새로운 썸네일 데이터 생성
         byte[] newThumbnailBytes = thumbnailGeneratorService.generate(pdfBytes);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #101 
> close #219 

## 📝작업 내용
> 작업한 내용을 작성해주세요.
### 파일 및 썸네일 생성
- 리포트 서비스에 리포트 파일과 썸네일 생성 후 경로 저장 위해 generateAndUploadReportFileAndThumbnail 메소드 작성
- 리포트 서비스에 S3매니저로 presigned 링크를 받아오는 generateDownloadLink 메소드 작성
- RedisReportConsumer에서 마감일에 분위기 트래커의 리포트와 리포트 파일과 썸네일을 generateAndUploadReportFileAndThumbnail로 생성해줌
- 테스트 위해서 즉시생성 API 작성

### 파일 다운로드 API
- 커맨드 서비스에 getDownloadLink 추가
- DTO 추가
- API 작성

## 🔎코드 설명(스크린샷(선택))
> 코드에 대한 설명을 작성해주세요.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

- AmazonS3Manager의 generatePresignedUrlForDownloadPdfAndWord 메소드에 한글 제목이 깨짐을 방지하기 위해서 RFC 5987 인코딩을 적용했습니다.

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
