### PR TITLE
fix/#249: 메인페이지 최근 문서 조회 시 mood tracker는 hashedId 반환하도록 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
+++ b/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
@@ -151,8 +151,16 @@ public class WorkspaceConverter {
     public WorkspaceResponseDTO.RecentDocument toRecentDocument(UserDocumentLastOpened userDocumentLastOpened) {
         String thumbnailUrl = s3Manager.generatePresignedUrl(userDocumentLastOpened.getThumbnailKeyName());
 
+        String documentId;
+
+        if(userDocumentLastOpened.getId().getDocumentType().equals(DocumentType.TEAM_MOOD_TRACKER)) {
+            documentId = hashIdUtil.encode(userDocumentLastOpened.getId().getDocumentId());
+        } else {
+            documentId = String.valueOf(userDocumentLastOpened.getId().getDocumentId());
+        }
+
         return WorkspaceResponseDTO.RecentDocument.builder()
-                .documentId(userDocumentLastOpened.getId().getDocumentId())
+                .documentId(documentId)
                 .title(userDocumentLastOpened.getTitle())
                 .documentType(userDocumentLastOpened.getId().getDocumentType())
                 .thumbnailUrl(thumbnailUrl)

--- a/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
@@ -93,8 +93,7 @@ public class WorkspaceResponseDTO {
     @Getter
     @Builder
     public static class RecentDocument {
-        @JsonSerialize(using = ToStringSerializer.class)
-        private Long documentId;
+        private String documentId;
         private String title;
         private DocumentType documentType;
         private String thumbnailUrl;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #249

## 📝작업 내용
> 메인페이지 최근 문서 조회 시 mood tracker는 hashedId 반환하도록 수정

## 🔎코드 설명(스크린샷(선택))
> X

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X
