### PR TITLE
feat/#252: 구글 로그인 후 프론트엔드 리다이렉트 URI 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2FailureHandler.java
@@ -2,6 +2,7 @@ package com.haru.api.domain.user.security.googleOauth2;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -10,6 +11,10 @@ import java.io.IOException;
 
 @Component
 public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    @Value("${google-login-frontend-url}")
+    String baseUrl;
+
     @Override
     public void onAuthenticationFailure(
             HttpServletRequest request,
@@ -18,6 +23,6 @@ public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler 
     ) throws IOException {
         String failureGoogleLoginUrl = "/auth/login/google/callback";
         // 프론트엔드 URL로 리다이렉트 (query param 전달)
-        response.sendRedirect("https://org.haru.it.kr" + failureGoogleLoginUrl + "?status=fail");
+        response.sendRedirect(baseUrl + failureGoogleLoginUrl + "?status=fail");
     }
 }

--- a/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2FailureHandler.java
@@ -18,6 +18,6 @@ public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler 
     ) throws IOException {
         String failureGoogleLoginUrl = "/auth/login/google/callback";
         // 프론트엔드 URL로 리다이렉트 (query param 전달)
-        response.sendRedirect("http://localhost:3000" + failureGoogleLoginUrl + "?status=fail");
+        response.sendRedirect("https://org.haru.it.kr" + failureGoogleLoginUrl + "?status=fail");
     }
 }

--- a/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2FailureHandler.java
@@ -21,8 +21,7 @@ public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler 
             HttpServletResponse response,
             AuthenticationException exception
     ) throws IOException {
-        String failureGoogleLoginUrl = "/auth/login/google/callback";
         // 프론트엔드 URL로 리다이렉트 (query param 전달)
-        response.sendRedirect(baseUrl + failureGoogleLoginUrl + "?status=fail");
+        response.sendRedirect(baseUrl + "?status=fail");
     }
 }

--- a/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2SuccessHandler.java
@@ -30,7 +30,6 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
             Authentication authentication
     ) throws IOException {
         StringBuilder redirectUrl = new StringBuilder();
-        String successGoogleLoginUrl = "/auth/login/google/callback";
         CustomOauth2UserDetails userDetails = (CustomOauth2UserDetails) authentication.getPrincipal();
         // 회원가입이든 로그인이든 똑같이 프론트엔드로 리다이렉트
         Long userId = userDetails.getUser().getId();
@@ -39,7 +38,6 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
         String refreshToken = userCommandService.generateAndSaveRefreshToken(key, refreshExpTime);
         // 프론트엔드 URL로 리다이렉트 (query param 전달)
         redirectUrl.append(baseUrl)
-                .append(successGoogleLoginUrl)
                 .append("?status=success")
                 .append("&userId=").append(userId)
                 .append("&profileImage=").append(userDetails.getUser().getProfileImage())

--- a/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2SuccessHandler.java
@@ -19,6 +19,8 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
     private int accessExpTime;
     @Value("${jwt.refresh-expiration}")
     private int refreshExpTime;
+    @Value("${google-login-frontend-url}")
+    String baseUrl;
     private final UserCommandService userCommandService;
 
     @Override
@@ -28,7 +30,6 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
             Authentication authentication
     ) throws IOException {
         StringBuilder redirectUrl = new StringBuilder();
-        String baseUrl = "https://org.haru.it.kr"; // 프론트엔드 URL
         String successGoogleLoginUrl = "/auth/login/google/callback";
         CustomOauth2UserDetails userDetails = (CustomOauth2UserDetails) authentication.getPrincipal();
         // 회원가입이든 로그인이든 똑같이 프론트엔드로 리다이렉트

--- a/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2SuccessHandler.java
@@ -28,7 +28,7 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
             Authentication authentication
     ) throws IOException {
         StringBuilder redirectUrl = new StringBuilder();
-        String baseUrl = "http://localhost:3000"; // 프론트엔드 URL
+        String baseUrl = "https://org.haru.it.kr"; // 프론트엔드 URL
         String successGoogleLoginUrl = "/auth/login/google/callback";
         CustomOauth2UserDetails userDetails = (CustomOauth2UserDetails) authentication.getPrincipal();
         // 회원가입이든 로그인이든 똑같이 프론트엔드로 리다이렉트

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -48,6 +48,8 @@ invite-url: invite-url
 
 survey-url: survey-url
 
+google-login-frontend-url: google-login-frontend-url
+
 instagram:
   client:
     id: "dummy-client-id"


### PR DESCRIPTION
## #️⃣연관된 이슈
> #252 

## 📝작업 내용
> 구글 로그인 후 프론트엔드 리다이렉트 URI 수정

## 🔎코드 설명(스크린샷(선택))
> CustomOAuth2FailureHandler.java파일과 CustomOAuth2SuccessHandler.java파일내에서 redirect-uri 'http://localhost:3000'에서 'https://org.haru.it.kr'로 수정

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
