### PR TITLE
feat/#280: S3 문서 삭제 및 문서제목 수정 로직 추가

### DIFF
--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -231,7 +231,7 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
                 // --- PDF 및 썸네일 생성/업데이트 로직 시작 ---
                 try {
                     // 생성된 PDF를 S3에 업로드
-                    String pdfKey = markdownFileUploader.createOrUpdatePdf(analysisResult, "proceedings/", currentMeeting.getProceedingKeyName());
+                    String pdfKey = markdownFileUploader.createOrUpdatePdf(analysisResult, "proceedings/", currentMeeting.getProceedingKeyName(), currentMeeting.getTitle());
                     currentMeeting.initProceedingKeyName(pdfKey);
 
                     // 썸네일 생성 및 업데이트

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
@@ -65,7 +65,7 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
         if (image != null) {
             // s3에 사진 추가하는 메서드
             String path = amazonS3Manager.generateKeyName("workspace/image");
-            keyName = amazonS3Manager.uploadFile(path, image);
+            keyName = amazonS3Manager.uploadMultipartFile(path, image);
         }
 
         // workspace entity 생성
@@ -99,7 +99,7 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
 
         // 이미지 수정
         if (image != null) {
-            amazonS3Manager.uploadFile(workspace.getKeyName(), image);
+            amazonS3Manager.uploadMultipartFile(workspace.getKeyName(), image);
         }
 
         return WorkspaceConverter.toWorkspaceDTO(workspace);

--- a/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
+++ b/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
@@ -28,7 +28,7 @@ public class AmazonS3Manager{
     private final AmazonConfig amazonConfig;
 
     //MultipartFile S3에 비공개 업로드
-    public String uploadFile(String keyName, MultipartFile file) {
+    public String uploadMultipartFile(String keyName, MultipartFile file) {
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(amazonConfig.getBucket())

--- a/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
+++ b/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
@@ -153,6 +153,28 @@ public class AmazonS3Manager{
         }
     }
 
+    public void updateFileTitle(String keyName, String newDisplayName) {
+
+        try {
+            String contentDisposition = createContentDisposition(newDisplayName);
+
+            CopyObjectRequest copyRequest = CopyObjectRequest.builder()
+                    .sourceBucket(amazonConfig.getBucket())
+                    .sourceKey(keyName)
+                    .destinationBucket(amazonConfig.getBucket())
+                    .destinationKey(keyName)
+                    .metadataDirective(MetadataDirective.REPLACE)
+                    .contentDisposition(contentDisposition)
+                    .build();
+
+            s3Client.copyObject(copyRequest);
+            log.info("S3 파일의 표시 이름 수정에 성공했습니다. Key: {}", keyName);
+        } catch (S3Exception e) {
+            log.error("S3 파일 표시 이름 수정 중 에러가 발생했습니다. Key: {}", keyName, e);
+            throw new RuntimeException("S3 파일 표시 이름 수정에 실패했습니다.", e);
+        }
+    }
+
     public void deleteFile(String keyName) {
         // keyName이 비어있거나 null인 경우, 삭제 작업을 수행하지 않고 경고 로그를 남깁니다.
         if (keyName == null || keyName.isBlank()) {

--- a/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
+++ b/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
@@ -8,10 +8,8 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
@@ -130,6 +128,30 @@ public class AmazonS3Manager{
             throw new RuntimeException("S3 file download failed", e);
         }
     }
+
+    public void deleteFile(String keyName) {
+        // keyName이 비어있거나 null인 경우, 삭제 작업을 수행하지 않고 경고 로그를 남깁니다.
+        if (keyName == null || keyName.isBlank()) {
+            log.warn("삭제할 S3 파일의 keyName이 유효하지 않습니다.");
+            return;
+        }
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(amazonConfig.getBucket())
+                .key(keyName)
+                .build();
+
+        try {
+            // S3 클라이언트를 통해 삭제 요청을 보냅니다.
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("S3 파일 삭제에 성공했습니다. Key: {}", keyName);
+        } catch (S3Exception e) {
+            // S3 API 호출 중 에러가 발생하면 로그를 남기고 런타임 예외를 발생시킵니다.
+            log.error("S3 파일 삭제 중 에러가 발생했습니다. Key: {}", keyName, e);
+            throw new RuntimeException("S3 파일 삭제에 실패했습니다.", e);
+        }
+    }
+
 
     public String generateKeyName(String path) {
         return path + '/' +UUID.randomUUID();

--- a/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
+++ b/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
@@ -35,7 +35,7 @@ public class MarkdownFileUploader {
             log.info("기존 PDF 갱신을 시작합니다. Key: {}", pdfKeyToUse);
         } else {
             // 기존 키가 없으면, 새로운 키를 생성
-            pdfKeyToUse = amazonS3Manager.generateKeyName("pdfs/" + featurePath) + ".pdf";
+            pdfKeyToUse = amazonS3Manager.generateKeyName(featurePath) + ".pdf";
             log.info("새로운 PDF 생성을 시작합니다. New Key: {}", pdfKeyToUse);
         }
 

--- a/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
+++ b/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
@@ -23,7 +23,7 @@ public class MarkdownFileUploader {
      * @param featurePath 파일이 저장될 기능별 경로 (예: "aimeeting")
      * @return 생성된 PDF 파일의 S3 key
      */
-    public String createOrUpdatePdf(String markdownText, String featurePath, String existingPdfKey) {
+    public String createOrUpdatePdf(String markdownText, String featurePath, String existingPdfKey, String fileTitle) {
         // 1. Markdown을 PDF 데이터로 변환
         byte[] pdfBytes = markdownToPdfConverter.convert(markdownText);
 
@@ -40,7 +40,7 @@ public class MarkdownFileUploader {
         }
 
         // 3. 결정된 키로 PDF 파일을 S3에 업로드
-        amazonS3Manager.uploadFile(pdfKeyToUse, pdfBytes, "application/pdf");
+        amazonS3Manager.uploadFileWithTitle(pdfKeyToUse, pdfBytes, "application/pdf", fileTitle);
         log.info("PDF 업로드/갱신 성공. Key: {}", pdfKeyToUse);
 
         // 4. 사용된 PDF의 key를 반환

--- a/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
+++ b/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
@@ -3,6 +3,9 @@ package com.haru.api.infra.s3;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.MetadataDirective;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 @Slf4j
 @Service
@@ -106,6 +109,14 @@ public class MarkdownFileUploader {
         return thumbnailKeyToUse;
     }
 
+
+    public void updateFileTitle(String keyName, String newFileTitle) {
+        if (keyName == null || keyName.isBlank()) {
+            log.warn("파일명을 수정할 S3 파일의 keyName이 유효하지 않습니다.");
+            return;
+        }
+        amazonS3Manager.updateFileTitle(keyName, newFileTitle);
+    }
 
     public void deleteFileAndThumbnail(String existingFileKeyName, String existingThumbnailKey){
 

--- a/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
+++ b/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
@@ -105,4 +105,18 @@ public class MarkdownFileUploader {
         // 4. 사용된 썸네일의 key를 반환
         return thumbnailKeyToUse;
     }
+
+
+    public void deleteFileAndThumbnail(String existingFileKeyName, String existingThumbnailKey){
+
+        if (existingFileKeyName != null && !existingFileKeyName.isBlank()) {
+            amazonS3Manager.deleteFile(existingFileKeyName);
+            log.info("기존 파일을 삭제합니다. Key: {}", existingFileKeyName);
+        }
+        if (existingThumbnailKey != null && !existingThumbnailKey.isBlank()) {
+            amazonS3Manager.deleteFile(existingThumbnailKey);
+            log.info("기존 썸네일을 삭제합니다. Key: {}", existingThumbnailKey);
+        }
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #280 

## 📝작업 내용

MarkdownFileUploader.updateFileTitle

updateFileTitle(String keyName, String newFileTitle)
기존의 keyName과 수정할 제목을 받아 S3 제목 수정
사용 keyName 고정
---
MarkdownFileUploader.deleteFileAndThumbnail

deleteFileAndThumbnail(String existingFileKeyName, String existingThumbnailKey)
파일keyName과 썸네일 keyName을 받아 파일 삭제 로직
내부적으로 null처리되어있어 썸네일이 없어도 동작


