### PR TITLE
feat/#288: AI 회의 삭제시 S3 파일 삭제 로직 추가

### DIFF
--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -153,6 +153,9 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
             throw new MemberHandler(ErrorStatus.MEMBER_NO_AUTHORITY);
         }
 
+        markdownFileUploader.deleteFileAndThumbnail(meeting.getProceedingKeyName(), meeting.getThumbnailKeyName());
+        markdownFileUploader.deleteS3File(meeting.getAudioFileKey());
+
         meetingRepository.delete(meeting);
     }
 

--- a/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
+++ b/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
@@ -3,9 +3,7 @@ package com.haru.api.infra.s3;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
-import software.amazon.awssdk.services.s3.model.MetadataDirective;
-import software.amazon.awssdk.services.s3.model.S3Exception;
+
 
 @Slf4j
 @Service
@@ -127,6 +125,14 @@ public class MarkdownFileUploader {
         if (existingThumbnailKey != null && !existingThumbnailKey.isBlank()) {
             amazonS3Manager.deleteFile(existingThumbnailKey);
             log.info("기존 썸네일을 삭제합니다. Key: {}", existingThumbnailKey);
+        }
+    }
+
+    public void deleteS3File(String audioFileKeyName){
+
+        if (audioFileKeyName != null && !audioFileKeyName.isBlank()) {
+            amazonS3Manager.deleteFile(audioFileKeyName);
+            log.info("음성 파일을 삭제합니다. Key: {}", audioFileKeyName);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #288 

## 📝작업 내용
> AI 회의 삭제시 S3에서 proceeding, thumbnail, audioFile 삭제
> S3 단일파일 삭제 로직 추가


