### PR TITLE
fix/#292: 회원가입 후 로그인 시 token 없으면 일반 회원가입 실행되도록 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
@@ -176,10 +176,13 @@ public class UserCommandServiceImpl implements UserCommandService{
         if (foundUser != null) {
             throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_EXISTS);
         } else {
+
             User user = UserConverter.toUsers(request, password);
             userRepository.save(user);
 
-            workspaceCommandService.acceptInvite(token);
+            if(token != null) {
+                workspaceCommandService.acceptInvite(token);
+            }
 
             return login(UserRequestDTO.LoginRequest.builder()
                             .email(request.getEmail())


### PR DESCRIPTION
## #️⃣연관된 이슈
> #292

## 📝작업 내용
> 회원가입 후 로그인 시 token 없으면 일반 회원가입 실행되도록 수정

## 🔎코드 설명(스크린샷(선택))
> X

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X