### PR TITLE
feat/#285: SNS 이벤트 제목 수정 시 S3의 다운로드 문서 제목 및 문서내 제목 수정, S3의 썸네일 이미지 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
@@ -146,10 +146,7 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
         SnsEvent savedSnsEvent = snsEventRepository.save(createdSnsEvent);
 
         // PDF, DOCX파일 바이트 배열로 생성 및 썸네일 생성 & 업로드 / DB에 keyName저장
-        String thumbnailKeyName = createAndUploadListFileAndThumbnail(
-                request,
-                savedSnsEvent
-        );
+        String thumbnailKeyName = createAndUploadListFileAndThumbnail(savedSnsEvent);
 
         // sns event 썸네일 key name 초기화
         savedSnsEvent.initThumbnailKeyName(thumbnailKeyName);
@@ -216,8 +213,13 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
         }
 
         snsEvent.updateTitle(request.getTitle());
-        snsEventRepository.save(snsEvent);
+        SnsEvent savedSnsEvent = snsEventRepository.save(snsEvent);
 
+        // S3문서 제목, S3 문서내 제목, 썸네일 이미지의 제목 변경
+        deleteS3FileAndThumnailImage(savedSnsEvent);
+        String thumbnailKeyName = createAndUploadListFileAndThumbnail(savedSnsEvent);
+        // sns event 썸네일 key name 초기화
+        savedSnsEvent.initThumbnailKeyName(thumbnailKeyName);
     }
 
     @Override
@@ -236,7 +238,8 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
             throw new SnsEventHandler(SNS_EVENT_NO_AUTHORITY);
         }
         snsEventRepository.delete(snsEvent);
-
+        // S3의 문서 및 썸네일 이미지 삭제
+        deleteS3FileAndThumnailImage(snsEvent);
     }
 
     @Override
@@ -255,13 +258,13 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
                 if (keyName == null || keyName.isEmpty()) {
                     throw new SnsEventHandler(SNS_EVENT_LIST_KEYNAME_NOT_FOUND);
                 }
-                downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, snsEventTitle + "_participnat_list.pdf");
+                downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, snsEventTitle + "_참여자_리스트.pdf");
             } else if (format == Format.DOCX) {
                 String keyName = snsEvent.getKeyNameParticipantWord();
                 if (keyName == null || keyName.isEmpty()) {
                     throw new SnsEventHandler(SNS_EVENT_LIST_KEYNAME_NOT_FOUND);
                 }
-                downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, snsEventTitle + "_participnat_list.docx");
+                downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, snsEventTitle + "_참여자_리스트.docx");
             } else {
                 throw new SnsEventHandler(SNS_EVENT_WRONG_FORMAT);
             }
@@ -271,13 +274,13 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
                 if (keyName == null || keyName.isEmpty()) {
                     throw new SnsEventHandler(SNS_EVENT_LIST_KEYNAME_NOT_FOUND);
                 }
-                downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, snsEventTitle + "_winner_list.pdf");
+                downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, snsEventTitle + "_당첨자_리스트.pdf");
             } else if (format == Format.DOCX) {
                 String keyName = snsEvent.getKeyNameWinnerWord();
                 if (keyName == null || keyName.isEmpty()) {
                     throw new SnsEventHandler(SNS_EVENT_LIST_KEYNAME_NOT_FOUND);
                 }
-                downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, snsEventTitle + "_winner_list.docx");
+                downloadLink = amazonS3Manager.generatePresignedUrlForDownloadPdfAndWord(keyName, snsEventTitle + "_당첨자_리스트.docx");
             } else {
                 throw new SnsEventHandler(SNS_EVENT_WRONG_FORMAT);
             }
@@ -324,13 +327,9 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
         } else {
             throw new SnsEventHandler(SNS_EVENT_WRONG_FORMAT);
         }
-
     }
 
-    private String createAndUploadListFileAndThumbnail(
-            SnsEventRequestDTO.CreateSnsRequest request,
-            SnsEvent snsEvent
-    ){
+    private String createAndUploadListFileAndThumbnail(SnsEvent snsEvent){
         String listHtmlParticipant = createListHtml(snsEvent, ListType.PARTICIPANT);
         String listHtmlWinner = createListHtml(snsEvent, ListType.WINNER);
         byte[] pdfBytesParticipant;
@@ -352,10 +351,10 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
             listHtmlWinner = fileConvertHelper.injectPageMarginStyle(listHtmlWinner);
             byte[] shiftedPdfBytesParticipant = fileConvertHelper.convertHtmlToPdf(listHtmlParticipant, fontBytes);
             byte[] shiftedPdfBytesWinner = fileConvertHelper.convertHtmlToPdf(listHtmlWinner, fontBytes);
-            pdfBytesParticipant =  addPdfTitle(shiftedPdfBytesParticipant, request.getTitle(), fontBytes);
-            pdfBytesWinner =  addPdfTitle(shiftedPdfBytesWinner, request.getTitle(), fontBytes);
-            docxBytesParticipant =  createWord(ListType.PARTICIPANT, request.getTitle(), snsEvent);
-            docxBytesWinner =  createWord(ListType.WINNER, request.getTitle(), snsEvent );
+            pdfBytesParticipant =  addPdfTitle(shiftedPdfBytesParticipant, snsEvent.getTitle() + " 참여자 리스트", fontBytes);
+            pdfBytesWinner =  addPdfTitle(shiftedPdfBytesWinner, snsEvent.getTitle() + " 당첨자 리스트", fontBytes);
+            docxBytesParticipant =  createWord(ListType.PARTICIPANT, snsEvent.getTitle() + " 참여자 리스트", snsEvent);
+            docxBytesWinner =  createWord(ListType.WINNER, snsEvent.getTitle() + " 당첨자 리스트", snsEvent );
         } catch (Exception e) {
             log.error("Error creating document: {}", e.getMessage());
             throw new SnsEventHandler(SNS_EVENT_DOWNLOAD_LIST_ERROR);
@@ -487,7 +486,7 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
         for (int i = 1; i <= totalPages; i++) {
             PdfContentByte over = stamper.getOverContent(i);
             over.beginText();
-            over.setFontAndSize(bf, 28f); // 글씨 크게 (28pt)
+            over.setFontAndSize(bf, 26f); // 글씨 크게 (28pt)
             // 페이지 폭 중앙 계산
             float x = reader.getPageSize(i).getWidth() / 2;
             // 페이지 상단에서 약간 내려오게 (70pt 여백)
@@ -630,5 +629,13 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
         run.setFontSize(fontSize);  // 전달받은 크기로 설정
         run.setBold(true);             // 굵게
         run.addBreak();                // 제목과 표 사이 한 줄 띄움
+    }
+
+    private void deleteS3FileAndThumnailImage(SnsEvent snsEvent) {
+        amazonS3Manager.deleteFile(snsEvent.getKeyNameParticipantPdf());
+        amazonS3Manager.deleteFile(snsEvent.getKeyNameParticipantWord());
+        amazonS3Manager.deleteFile(snsEvent.getKeyNameWinnerPdf());
+        amazonS3Manager.deleteFile(snsEvent.getKeyNameWinnerWord());
+        amazonS3Manager.deleteFile(snsEvent.getThumbnailKeyName());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #285 

## 📝작업 내용
> SNS 이벤트 제목 수정 시 S3의 다운로드 문서 제목 및 문서내 제목 수정, S3의 썸네일 이미지 수정

## 🔎코드 설명(스크린샷(선택))
> SnsEventCommandServiceImpl.java 파일 수정
- SNS 이벤트 제목 수정 시 S3의 다운로드 문서 제목 및 문서내 제목 수정, S3의 썸네일 이미지 수정

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
