### PR TITLE
fix/#309: SNS 이벤트 수정 시 최근 문서의 썸네일 이미지 키도 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
@@ -16,4 +16,6 @@ public interface UserDocumentLastOpenedService {
     void deleteRecordsForWorkspaceUsers(Documentable document);
 
     void updateRecordsForWorkspaceUsers(Documentable document, TitleHolder titleHolder);
+
+    void updateRecordsTitleAndThumbnailForWorkspaceUsers(List<User> usersInWorkspace, Documentable documentable, TitleHolder titleHolder);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
@@ -112,4 +112,18 @@ public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpened
         return recordsToProcess;
     }
 
+    @Override
+    @Transactional
+    public void updateRecordsTitleAndThumbnailForWorkspaceUsers(List<User> usersInWorkspace, Documentable documentable, TitleHolder titleHolder) {
+        // 해당 문서 id, 문서 타입에 해당하는 last opened 튜플 검색
+        List<UserDocumentLastOpened> recordsToUpdate = userDocumentLastOpenedRepository.findByDocumentIdAndDocumentType(documentable.getId(), documentable.getDocumentType());
+
+        if (!recordsToUpdate.isEmpty()) {
+            for (UserDocumentLastOpened record : recordsToUpdate) {
+                record.updateTitle(titleHolder.getTitle());
+                record.updateThumbnailKeyName(documentable.getThumbnailKeyName());
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
@@ -221,9 +221,15 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
 
         // S3문서 제목, S3 문서내 제목, 썸네일 이미지의 제목 변경
         deleteS3FileAndThumnailImage(savedSnsEvent);
+
         String thumbnailKeyName = createAndUploadListFileAndThumbnail(savedSnsEvent);
         // sns event 썸네일 key name 초기화
         savedSnsEvent.initThumbnailKeyName(thumbnailKeyName);
+
+        // sns event 생성 시 워크스페이스에 속해있는 모든 유저에 대해
+        // last opened 테이블에 마지막으로 연 시간은 null로하여 추가
+        List<User> usersInWorkspace = userWorkspaceRepository.findUsersByWorkspaceId(savedSnsEvent.getWorkspace().getId());
+        userDocumentLastOpenedService.updateRecordsTitleAndThumbnailForWorkspaceUsers(usersInWorkspace, savedSnsEvent, request);
     }
 
     @Override


### PR DESCRIPTION
## #️⃣연관된 이슈
> #309

## 📝작업 내용
> 메인페이지 최근 문서 조회시 수정된 SNS 이벤트의 썸네일 이미지가 업데이트 되지 않는 버그 발생. SNS 이벤트 수정 시 최근 문서의 썸네일 이미지 키도 수정하여 해결 

## 🔎코드 설명(스크린샷(선택))
> UserDocumentLastOpenedServiceImpl.java파일에 updateRecordsTitleAndThumbnailForWorkspaceUsers라는 LastOpened의 title과 썸네일 이미지 수정하는 메소드 생성하여 SnsEventCommandServiceImpl에서 사용

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
