### PR TITLE
feat/#311: 워크스페이스에 연동된 인스타그램 계정 조회하는 API 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
@@ -166,4 +166,22 @@ public class SnsEventController {
         );
     }
 
+    @Operation(
+            summary = "워크스페이스에 연동된 인스타그램 계정 조회 API [v1.0 (2025-08-20)]",
+            description = "# [v1.0 (2025-08-20)](https://www.notion.so/API-21e5da7802c581cca23dff937ac3f155?p=2545da7802c5801299c9f47578ba7d75&pm=s)" +
+                    " 워크스페이스에 연동된 인스타그램 계정을 조회하는 API입니다. Path Variable에 workspaceId를 넣어 요청해주세요."
+    )
+    @GetMapping("/{workspaceId}/instagram")
+    public ApiResponse<SnsEventResponseDTO.getInstagramAccountName> getInstagramAccountName(
+            @PathVariable String workspaceId,
+            @Parameter(hidden = true) @AuthUser User user,
+            @Parameter(hidden = true) @AuthWorkspace Workspace workspace
+    ) {
+        return ApiResponse.onSuccess(
+                snsEventQueryService.getInstagramAccountName(
+                        user,
+                        workspace
+                )
+        );
+    }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/converter/SnsEventConverter.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/converter/SnsEventConverter.java
@@ -99,4 +99,12 @@ public class SnsEventConverter {
                 .account(winner.getNickname())
                 .build();
     }
+
+    public static SnsEventResponseDTO.getInstagramAccountName toGetInstagramAccountName(
+            String instagramAccountName
+    ) {
+        return SnsEventResponseDTO.getInstagramAccountName.builder()
+                .instagramAccountName(instagramAccountName)
+                .build();
+    }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventResponseDTO.java
@@ -117,4 +117,12 @@ public class SnsEventResponseDTO {
     public static class ListDownLoadLinkResponse {
         private String downloadLink;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getInstagramAccountName {
+        private String instagramAccountName;
+    }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventQueryService.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventQueryService.java
@@ -10,4 +10,6 @@ public interface SnsEventQueryService {
     SnsEventResponseDTO.GetSnsEventListRequest getSnsEventList(User user, Workspace workspace);
 
     SnsEventResponseDTO.GetSnsEventRequest getSnsEvent(User user, SnsEvent snsEvent);
+
+    SnsEventResponseDTO.getInstagramAccountName getInstagramAccountName(User user, Workspace workspace);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventQueryServiceImpl.java
@@ -48,4 +48,16 @@ public class SnsEventQueryServiceImpl implements SnsEventQueryService {
         );
 
     }
+
+    @Override
+    public SnsEventResponseDTO.getInstagramAccountName getInstagramAccountName(User user, Workspace workspace) {
+        if (workspace.getInstagramAccountName() == null) {
+            return SnsEventConverter.toGetInstagramAccountName(
+                    ""
+            );
+        }
+        return SnsEventConverter.toGetInstagramAccountName(
+                workspace.getInstagramAccountName()
+        );
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #311

## 📝작업 내용
> 워크스페이스에 연동된 인스타그램 계정 조회하는 API 구현

## 🔎코드 설명(스크린샷(선택))
> controller, service, repository, converter, dto, entity를 사용해 워크스페이스에 연동된 인스타그램 계정 조회하는 API 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
