### PR TITLE
fix/#325: Meeting 삭제시 연관된 speechSegment도 삭제되도록 추가

### DIFF
--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -163,6 +163,11 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
         markdownFileUploader.deleteS3File(foundMeeting.getProceedingWordKeyName());
         markdownFileUploader.deleteS3File(foundMeeting.getAudioFileKey());
 
+
+        List<SpeechSegment> segmentsToDelete = speechSegmentRepository.findByMeeting(foundMeeting);
+
+        speechSegmentRepository.deleteAll(segmentsToDelete);
+
         meetingRepository.delete(foundMeeting);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #325 

## 📝작업 내용
> 
Meeting 삭제시
meeting과 연관된 speechSegment 삭제 로직 추가
