### PR TITLE
feat/#330: AI meeting 파일 업로드 및 다운로드시 확장자 추가

### DIFF
--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -139,7 +139,8 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
 
         meeting.updateTitle(request.getTitle());
 
-        markdownFileUploader.updateFileTitle(meeting.getProceedingPdfKeyName(), request.getTitle());
+        markdownFileUploader.updateFileTitle(meeting.getProceedingPdfKeyName(), request.getTitle() + ".pdf");
+        markdownFileUploader.updateFileTitle(meeting.getProceedingWordKeyName(), request.getTitle() + ".docx");
 
         meetingRepository.save(meeting);
     }

--- a/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
+++ b/src/main/java/com/haru/api/infra/s3/AmazonS3Manager.java
@@ -153,6 +153,7 @@ public class AmazonS3Manager{
         }
     }
 
+    // newDisplayName에 확장자 포함되어있음
     public void updateFileTitle(String keyName, String newDisplayName) {
 
         try {

--- a/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
+++ b/src/main/java/com/haru/api/infra/s3/MarkdownFileUploader.java
@@ -42,7 +42,7 @@ public class MarkdownFileUploader {
         }
 
         // 3. 결정된 키로 PDF 파일을 S3에 업로드
-        amazonS3Manager.uploadFileWithTitle(pdfKeyToUse, pdfBytes, "application/pdf", fileTitle);
+        amazonS3Manager.uploadFileWithTitle(pdfKeyToUse, pdfBytes, "application/pdf", fileTitle + ".pdf");
         log.info("PDF 업로드/갱신 성공. Key: {}", pdfKeyToUse);
 
         // 4. 사용된 PDF의 key를 반환
@@ -65,7 +65,7 @@ public class MarkdownFileUploader {
 
         // 3. 결정된 키로 Word 파일을 S3에 업로드
         String contentType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-        amazonS3Manager.uploadFileWithTitle(wordKeyToUse, wordBytes, contentType, fileTitle);
+        amazonS3Manager.uploadFileWithTitle(wordKeyToUse, wordBytes, contentType, fileTitle + ".docx");
         log.info("Word 파일 업로드/갱신 성공. Key: {}", wordKeyToUse);
 
         // 4. 사용된 Word의 key를 반환


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #330 

업로드시
```java
amazonS3Manager.uploadFileWithTitle(pdfKeyToUse, pdfBytes, "application/pdf", fileTitle + ".pdf");
amazonS3Manager.uploadFileWithTitle(wordKeyToUse, wordBytes, contentType, fileTitle + ".docx");
```

제목 수정시
```java
markdownFileUploader.updateFileTitle(meeting.getProceedingPdfKeyName(), request.getTitle() + ".pdf");
markdownFileUploader.updateFileTitle(meeting.getProceedingWordKeyName(), request.getTitle() + ".docx");
```