### PR TITLE
refactor/#336: 설문 마감일시에 실패시 retry 전략

### DIFF
--- a/src/main/java/com/haru/api/domain/moodTracker/controller/MoodTrackerController.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/controller/MoodTrackerController.java
@@ -255,7 +255,7 @@ public class MoodTrackerController {
 
     @PostMapping("/{mood-tracker-hashed-Id}/report-test")
     @Operation(
-            summary = "분위기 트래커 설문 리포트 즉시 생성 테스트 API",
+            summary = "분위기 트래커 설문 리포트 즉시 생성 API",
             description = "# [v1.0 (2025-07-26)](https://www.notion.so/23f5da7802c58080b4a5e6d24b47d924) 해당 ID의 분위기 트래커 설문 리포트를 즉시 생성합니다."
     )
     @Parameters({
@@ -274,7 +274,7 @@ public class MoodTrackerController {
 
     @PostMapping("/{mood-tracker-hashed-Id}/report-file-thumbnail-test")
     @Operation(
-            summary = "분위기 트래커 설문 리포트, 파일, 썸네일 즉시 생성 테스트 API",
+            summary = "분위기 트래커 설문 리포트, 파일, 썸네일 즉시 생성 테스트 API + redis에서 제외하여 마감일시에 중복 생성 불가",
             description = "# [v1.0 (2025-08-14)](https://www.notion.so/24f5da7802c58019a1f7d9c8e882226e) 해당 ID의 분위기 트래커 설문 리포트를 즉시 생성합니다."
     )
     @Parameters({

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandServiceImpl.java
@@ -19,6 +19,7 @@ import com.haru.api.global.annotation.UpdateDocumentTitle;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.*;
 import com.haru.api.global.util.HashIdUtil;
+import com.haru.api.infra.redis.RedisReportConsumer;
 import com.haru.api.infra.redis.RedisReportProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,6 +53,7 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
 
     private final MoodTrackerReportService moodTrackerReportService;
     private final RedisReportProducer redisReportProducer;
+    private final RedisReportConsumer redisReportConsumer;
 
     private final HashIdUtil hashIdUtil;
 
@@ -318,6 +320,10 @@ public class MoodTrackerCommandServiceImpl implements MoodTrackerCommandService 
     public void generateReportFileAndThumbnailTest(
             MoodTracker moodTracker
     ) {
+        // 중복 처리 제외
+        redisReportConsumer.removeFromQueue(moodTracker.getId());
+
+        // 즉시 생성
         moodTrackerReportService.generateAndUploadReportFileAndThumbnail(moodTracker.getId());
     }
 }

--- a/src/main/java/com/haru/api/infra/redis/RedisReportConsumer.java
+++ b/src/main/java/com/haru/api/infra/redis/RedisReportConsumer.java
@@ -44,4 +44,18 @@ public class RedisReportConsumer {
             }
         }
     }
+
+    @Transactional
+    public void removeFromQueue(Long moodTrackerId) {
+        try {
+            Long removed = redisTemplate.opsForZSet().remove(QUEUE_KEY, moodTrackerId.toString());
+            if (removed != null && removed > 0) {
+                log.info("즉시 생성 API 호출로 큐에서 제거됨: {}", moodTrackerId);
+            } else {
+                log.info("큐에 존재하지 않아 제거할 항목 없음: {}", moodTrackerId);
+            }
+        } catch (Exception e) {
+            log.error("큐 제거 실패: {}", moodTrackerId, e);
+        }
+    }
 }


### PR DESCRIPTION
- 즉시 생성 시에 중복 처리 제외하도록 반영

## #️⃣연관된 이슈
> close #336 

## 📝작업 내용
> 작업한 내용을 작성해주세요.
- FE에서 설문 마감일시에 리포트 생성 실패시, 즉시 생성 API를 사용
- 즉시 생성 API 호출시에 redis queue에서 제외하는 로직 추가

## 🔎코드 설명(스크린샷(선택))
> 코드에 대한 설명을 작성해주세요.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
