### PR TITLE
feat/#337: 인스타그램 redirect-uri 한개 더 추가 및 인스타그램 API 연동 시 redirect-uri동적으로 바꾸는 기능 추가

### DIFF
--- a/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
@@ -4,6 +4,7 @@ import com.haru.api.domain.snsEvent.dto.SnsEventRequestDTO;
 import com.haru.api.domain.snsEvent.dto.SnsEventResponseDTO;
 import com.haru.api.domain.snsEvent.entity.SnsEvent;
 import com.haru.api.domain.snsEvent.entity.enums.Format;
+import com.haru.api.domain.snsEvent.entity.enums.InstagramRedirectType;
 import com.haru.api.domain.snsEvent.entity.enums.ListType;
 import com.haru.api.domain.snsEvent.service.SnsEventCommandService;
 import com.haru.api.domain.snsEvent.service.SnsEventQueryService;
@@ -56,19 +57,20 @@ public class SnsEventController {
     }
 
     @Operation(
-            summary = "인스타그램 연동 API [v1.1 (2025-08-07)]",
-            description = "# [v1.1 (2025-08-07)](https://www.notion.so/API-21e5da7802c581cca23dff937ac3f155?p=23f5da7802c5803b98abe74d511c2cf4&pm=s)" +
+            summary = "인스타그램 연동 API [v1.1 (2025-08-21)]",
+            description = "# [v1.1 (2025-08-21)](https://www.notion.so/API-21e5da7802c581cca23dff937ac3f155?p=23f5da7802c5803b98abe74d511c2cf4&pm=s)" +
                     " 인스타그램 로그인 후 인증 서버로부터 받은 code를 header에 넣어주시고, workspaceId를 Path Variable로 넣어주세요."
     )
     @PostMapping("/{workspaceId}/link-instagram")
     public ApiResponse<SnsEventResponseDTO.LinkInstagramAccountResponse> linkInstagramAccount(
             @RequestHeader("code") String code,
             @PathVariable String workspaceId,
+            @RequestParam InstagramRedirectType instagramRedirectType,
             @Parameter(hidden = true) @AuthWorkspace Workspace workspace
     ) {
         System.out.println("Received accessToken: " + code);
         return ApiResponse.onSuccess(
-                snsEventCommandService.getInstagramAccessTokenAndAccount(code, workspace)
+                snsEventCommandService.getInstagramAccessTokenAndAccount(code, workspace, instagramRedirectType)
         );
     }
 

--- a/src/main/java/com/haru/api/domain/snsEvent/entity/enums/InstagramRedirectType.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/entity/enums/InstagramRedirectType.java
@@ -1,0 +1,5 @@
+package com.haru.api.domain.snsEvent.entity.enums;
+
+public enum InstagramRedirectType {
+    ONBOARDING, WORKSPACE
+}

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
@@ -4,6 +4,7 @@ import com.haru.api.domain.snsEvent.dto.SnsEventRequestDTO;
 import com.haru.api.domain.snsEvent.dto.SnsEventResponseDTO;
 import com.haru.api.domain.snsEvent.entity.SnsEvent;
 import com.haru.api.domain.snsEvent.entity.enums.Format;
+import com.haru.api.domain.snsEvent.entity.enums.InstagramRedirectType;
 import com.haru.api.domain.snsEvent.entity.enums.ListType;
 import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.workspace.entity.Workspace;
@@ -11,7 +12,7 @@ import com.haru.api.domain.workspace.entity.Workspace;
 public interface SnsEventCommandService {
     SnsEventResponseDTO.CreateSnsEventResponse createSnsEvent(User user, Workspace workspace, SnsEventRequestDTO.CreateSnsRequest request);
 
-    SnsEventResponseDTO.LinkInstagramAccountResponse getInstagramAccessTokenAndAccount(String code, Workspace workspace);
+    SnsEventResponseDTO.LinkInstagramAccountResponse getInstagramAccessTokenAndAccount(String code, Workspace workspace, InstagramRedirectType instagramRedirectType);
 
     void updateSnsEventTitle(User user, SnsEvent snsEvent, SnsEventRequestDTO.UpdateSnsEventRequest request);
 

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
@@ -8,6 +8,7 @@ import com.haru.api.domain.snsEvent.entity.Participant;
 import com.haru.api.domain.snsEvent.entity.SnsEvent;
 import com.haru.api.domain.snsEvent.entity.Winner;
 import com.haru.api.domain.snsEvent.entity.enums.Format;
+import com.haru.api.domain.snsEvent.entity.enums.InstagramRedirectType;
 import com.haru.api.domain.snsEvent.entity.enums.ListType;
 import com.haru.api.domain.snsEvent.repository.ParticipantRepository;
 import com.haru.api.domain.snsEvent.repository.SnsEventRepository;
@@ -170,14 +171,18 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
     @Transactional
     public SnsEventResponseDTO.LinkInstagramAccountResponse getInstagramAccessTokenAndAccount(
             String code,
-            Workspace workspace
+            Workspace workspace,
+            InstagramRedirectType instagramRedirectType
     ) {
         String shortLivedAccessToken;
         String longLivedAccessToken;
         Map<String, Object> userInfo;
         try {
             // 1. Access Token 요청
-            shortLivedAccessToken = instagramOauth2RestTemplate.getShortLivedAccessTokenUrl(code);
+            shortLivedAccessToken = instagramOauth2RestTemplate.getShortLivedAccessTokenUrl(
+                    code,
+                    instagramRedirectType
+            );
             // 2. 단기 토큰을 장기(Long-Lived) 토큰으로 교환
             longLivedAccessToken = instagramOauth2RestTemplate.getLongLivedAccessToken(shortLivedAccessToken);
             // 3. 장기 토큰으로 사용자 계정 정보 요청

--- a/src/main/java/com/haru/api/infra/api/restTemplate/InstagramOauth2RestTemplate.java
+++ b/src/main/java/com/haru/api/infra/api/restTemplate/InstagramOauth2RestTemplate.java
@@ -1,5 +1,6 @@
 package com.haru.api.infra.api.restTemplate;
 
+import com.haru.api.domain.snsEvent.entity.enums.InstagramRedirectType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -21,12 +22,17 @@ public class InstagramOauth2RestTemplate {
     private String instagramClientId;
     @Value("${instagram.client.secret}")
     private String instagramClientSecret;
-    @Value("${instagram.redirect.uri}")
-    private String instagramRedirectUri;
+    @Value("${instagram.redirect.uri-onboarding}")
+    private String instagramRedirectUriOnboarding;
+    @Value("${instagram.redirect.uri-workspace}")
+    private String instagramRedirectUriWorkspace;
 
     private final RestTemplate restTemplate;
 
-    public String getShortLivedAccessTokenUrl(String code) {
+    public String getShortLivedAccessTokenUrl(
+            String code,
+            InstagramRedirectType instagramRedirectType
+    ) {
         // 1. Access Token 요청
         String tokenUrl = "https://api.instagram.com/oauth/access_token";
         RestTemplate restTemplate = new RestTemplate();
@@ -35,7 +41,13 @@ public class InstagramOauth2RestTemplate {
         params.add("client_id", instagramClientId);          // 인스타 앱의 클라이언트 ID
         params.add("client_secret", instagramClientSecret);  // 인스타 앱의 클라이언트 시크릿
         params.add("grant_type", "authorization_code");
-        params.add("redirect_uri", instagramRedirectUri);              // 인가코드와 동일한 redirect_uri
+        // 인가코드와 동일한 redirect_uri
+        if (instagramRedirectType == InstagramRedirectType.ONBOARDING) {
+            params.add("redirect_uri", instagramRedirectUriOnboarding);
+        } else if(instagramRedirectType == InstagramRedirectType.WORKSPACE) {
+            System.out.println("Using workspace redirect URI: " + instagramRedirectUriWorkspace);
+            params.add("redirect_uri", instagramRedirectUriWorkspace);
+        }
         params.add("code", code);
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -57,4 +57,5 @@ instagram:
     id: "dummy-client-id"
     secret: "dummy-client-secret"
   redirect:
-    uri: "dummy-redirect-uri"
+    uri-onboarding: "dummy-redirect-uri"
+    uri-workspace: "dummy-redirect-uri"


### PR DESCRIPTION
## #️⃣연관된 이슈
> #337 

## 📝작업 내용
> 인스타그램 redirect-uri 한개 더 추가 및 인스타그램 API 연동 시 redirect-uri동적으로 바꾸는 기능 추가

## 🔎코드 설명(스크린샷(선택))
> InstagramOauth2RestTemplate.java파일에 redirect-uri동적으로 바꾸는 기능 추가

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
