### PR TITLE
feat/#345: AI 회의록 수정 시 최근 문서 조회에 업데이트 된 썸네일 반영

### DIFF
--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
@@ -18,4 +18,6 @@ public interface UserDocumentLastOpenedService {
     void updateRecordsForWorkspaceUsers(Documentable document, TitleHolder titleHolder);
 
     void updateRecordsTitleAndThumbnailForWorkspaceUsers(List<User> usersInWorkspace, Documentable documentable, TitleHolder titleHolder);
+
+    void updateRecordsThumbnailForWorkspaceUsers(List<User> usersInWorkspace, Documentable documentable);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
@@ -127,4 +127,17 @@ public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpened
         }
     }
 
+    @Override
+    @Transactional
+    public void updateRecordsThumbnailForWorkspaceUsers(List<User> usersInWorkspace, Documentable documentable) {
+        // 해당 문서 id, 문서 타입에 해당하는 last opened 튜플 검색
+        List<UserDocumentLastOpened> recordsToUpdate = userDocumentLastOpenedRepository.findByDocumentIdAndDocumentType(documentable.getId(), documentable.getDocumentType());
+
+        if (!recordsToUpdate.isEmpty()) {
+            for (UserDocumentLastOpened record : recordsToUpdate) {
+                record.updateThumbnailKeyName(documentable.getThumbnailKeyName());
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -195,6 +195,10 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
             String newThumbnailKey = markdownFileUploader.createOrUpdateThumbnail(pdfKey, "meeting" + meeting.getId(), meeting.getThumbnailKeyName());
             log.info("회의록 썸네일 생성/업데이트 완료. Key: {}", newThumbnailKey);
 
+            // Meeting AI 회의록 수정 시 워크스페이스에 속해있는 모든 유저에 대해 썸네일 이미지 키 수정
+            foundMeeting.initProceedingPdfKeyName(newThumbnailKey);
+            List<User> usersInWorkspace = userWorkspaceRepository.findUsersByWorkspaceId(foundMeeting.getWorkspace().getId());
+            userDocumentLastOpenedService.updateRecordsThumbnailForWorkspaceUsers(usersInWorkspace, foundMeeting);
         } catch (Exception e) {
             log.error("meetingId: {}의 PDF 또는 썸네일 생성/업로드 중 에러 발생", meeting.getId(), e);
             throw new RuntimeException("파일 갱신 중 오류가 발생했습니다.", e);


### PR DESCRIPTION
## #️⃣연관된 이슈
> #345

## 📝작업 내용
> AI 회의록 수정 시 최근 문서 조회에 업데이트 된 썸네일 반영

## 🔎코드 설명(스크린샷(선택))
> MeetingCommandServiceImpl.java파일의 adjustProceeding메소드에 최근문서조회에 업데이트된 썸네일 반영되도록 하는 로직 추가

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
